### PR TITLE
chore: ignore private CLAUDE.local.md files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ roles/splunk_docker/files/*.spl
 
 # Terraform inventory (generated at runtime)
 inventory/terraform_inventory.json
+
+# Private AI assistant instructions (not committed to git)
+.CLAUDE.local.md
+CLAUDE.local.md


### PR DESCRIPTION
## Summary
- Add .CLAUDE.local.md and CLAUDE.local.md to .gitignore

## Rationale
Private AI assistant instructions containing sensitive notes, failures, and secret-related information should not be committed to git.

## Test plan
- [x] Verify .CLAUDE.local.md is ignored by git
- [x] Verify CLAUDE.local.md is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)