### PR TITLE
feat: add ai and claude Splunk indexes

### DIFF
--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -51,6 +51,12 @@ splunk_docker_index_default_frozen_time_secs: 31536000
 
 # Indexes to create
 splunk_docker_indexes:
+  - name: ai
+    max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
+    frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"
+  - name: claude
+    max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
+    frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"
   - name: firewall
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"


### PR DESCRIPTION
## Summary
- Add two new custom Splunk indexes: `ai` and `claude`
- Both configured with 100GB max size and 365 days retention
- Follow existing index configuration pattern

## Changes
- Updated `roles/splunk_docker/defaults/main.yml` to add new indexes to `splunk_docker_indexes` list
- Indexes deployed via Ansible and verified working

## Configuration
Each index:
- `maxTotalDataSizeMB`: 102400 (100GB)
- `frozenTimePeriodInSecs`: 31536000 (365 days)
- Standard paths: homePath, coldPath, thawedPath

## Test Plan
- [x] Ansible deployment succeeded
- [x] Container restarted successfully
- [x] Test events sent to both indexes via HEC (all returned Success)
- [x] Verified indexes are accepting data

## Related
Part of ongoing Splunk infrastructure improvements for AI/Claude logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `ai` and `claude` Splunk indexes with default settings to `main.yml`.
> 
>   - **Indexes**:
>     - Add `ai` and `claude` indexes to `splunk_docker_indexes` in `main.yml`.
>     - Both indexes use default settings: 100GB max size, 365 days retention.
>   - **Configuration**:
>     - Updated `roles/splunk_docker/defaults/main.yml` to include new indexes.
>   - **Deployment**:
>     - Indexes deployed and verified via Ansible.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-splunk&utm_source=github&utm_medium=referral)<sup> for 7b5099f3ea5a6fb1e1d338b4b2e35647039b9fe6. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->