### PR TITLE
feat: add JRE-21 and Splunk DB Connect

### DIFF
--- a/inventory/group_vars/splunk.yml
+++ b/inventory/group_vars/splunk.yml
@@ -6,6 +6,9 @@ splunk_admin_user: admin
 splunk_service_state: started
 splunk_service_enabled: true
 
+# Enable Java for Splunk DB Connect
+splunk_docker_java_enabled: true
+
 # Data disk configuration
 splunk_data_disk_device: /dev/sdb1
 splunk_data_disk_mount_path: /opt/splunk/var/lib/splunk

--- a/playbooks/validate.yml
+++ b/playbooks/validate.yml
@@ -129,6 +129,20 @@
       ansible.builtin.set_fact:
         validation_results: "{{ validation_results + [{'check': 'Firewall configured', 'passed': firewall_script.stat.exists}] }}"
 
+    - name: Check Java is accessible in Splunk container
+      community.docker.docker_container_exec:
+        container: splunk
+        command: "{{ splunk_docker_java_home }}/bin/java -version"
+      register: java_check
+      failed_when: false
+      vars:
+        splunk_docker_java_home: "/usr/lib/jvm/temurin-21-jre-amd64"
+
+    - name: Record Java availability status
+      ansible.builtin.set_fact:
+        validation_results: >-
+          {{ validation_results + [{'check': 'Java accessible in container', 'passed': (java_check.rc | default(1)) == 0}] }}
+
     - name: Get container disk usage
       ansible.builtin.command:
         cmd: df -h /opt/splunk

--- a/playbooks/validate.yml
+++ b/playbooks/validate.yml
@@ -19,6 +19,9 @@
     splunk_docker_hec_port: 8088
     splunk_docker_config_dir: /opt/splunk-config
     splunk_docker_etc_dir: /opt/splunk/etc
+    splunk_docker_java_enabled: true
+    splunk_docker_java_version: "21"
+    splunk_docker_java_home: "/usr/lib/jvm/temurin-{{ splunk_docker_java_version }}-jre-amd64"
 
   tasks:
     - name: Check Docker service is running
@@ -135,13 +138,13 @@
         command: "{{ splunk_docker_java_home }}/bin/java -version"
       register: java_check
       failed_when: false
-      vars:
-        splunk_docker_java_home: "/usr/lib/jvm/temurin-21-jre-amd64"
+      when: splunk_docker_java_enabled
 
     - name: Record Java availability status
       ansible.builtin.set_fact:
         validation_results: >-
           {{ validation_results + [{'check': 'Java accessible in container', 'passed': (java_check.rc | default(1)) == 0}] }}
+      when: splunk_docker_java_enabled
 
     - name: Get container disk usage
       ansible.builtin.command:

--- a/playbooks/validate.yml
+++ b/playbooks/validate.yml
@@ -13,15 +13,11 @@
   become: true
   gather_facts: true
 
+  vars_files:
+    - ../roles/splunk_docker/defaults/main.yml
+
   vars:
     validation_results: []
-    splunk_docker_web_port: 8000
-    splunk_docker_hec_port: 8088
-    splunk_docker_config_dir: /opt/splunk-config
-    splunk_docker_etc_dir: /opt/splunk/etc
-    splunk_docker_java_enabled: true
-    splunk_docker_java_version: "21"
-    splunk_docker_java_home: "/usr/lib/jvm/temurin-{{ splunk_docker_java_version }}-jre-amd64"
 
   tasks:
     - name: Check Docker service is running
@@ -127,15 +123,17 @@
       ansible.builtin.stat:
         path: "{{ splunk_docker_config_dir }}/firewall.sh"
       register: firewall_script
+      when: splunk_docker_firewall_enabled | default(false)
 
     - name: Record firewall status
       ansible.builtin.set_fact:
         validation_results: "{{ validation_results + [{'check': 'Firewall configured', 'passed': firewall_script.stat.exists}] }}"
+      when: splunk_docker_firewall_enabled | default(false)
 
     - name: Check Java is accessible in Splunk container
       community.docker.docker_container_exec:
         container: splunk
-        command: "{{ splunk_docker_java_home }}/bin/java -version"
+        command: "{{ splunk_docker_java_container_home }}/bin/java -version"
       register: java_check
       failed_when: false
       when: splunk_docker_java_enabled

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -86,15 +86,21 @@ splunk_docker_user: "41812"
 splunk_docker_group: "41812"
 
 # Java Runtime for Splunk DB Connect
-splunk_docker_java_enabled: true
+# Disabled by default; enable in inventory for hosts that need DB Connect.
+splunk_docker_java_enabled: false
 splunk_docker_java_version: "21"
+# Pin to major version; for full pin use e.g. temurin-21-jre=21.0.7+6-1
 splunk_docker_java_package: "temurin-{{ splunk_docker_java_version }}-jre"
-splunk_docker_java_home: "/usr/lib/jvm/temurin-{{ splunk_docker_java_version }}-jre-amd64"
+splunk_docker_java_arch: "amd64"
+splunk_docker_java_home: "/usr/lib/jvm/temurin-{{ splunk_docker_java_version }}-jre-{{ splunk_docker_java_arch }}"
+# Container-internal path where the JRE is bind-mounted (decoupled from host path)
+splunk_docker_java_container_home: "/opt/java"
 
 # Technology Add-ons (TAs) to install
 # TAs must be placed in roles/splunk_docker/files/ as .tar, .tgz, or .spl files
 splunk_docker_unifi_ta_version: 1.0.2+00b9ecb
 splunk_docker_duck_yeah_version: 234
+# Splunkbase strips dots from version strings in filenames: 4.2.1 -> 421
 splunk_docker_dbconnect_version: "421"
 splunk_docker_addons:
   - name: TA-unifi-cloud

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -85,10 +85,17 @@ splunk_docker_firewall_enabled: false
 splunk_docker_user: "41812"
 splunk_docker_group: "41812"
 
+# Java Runtime for Splunk DB Connect
+splunk_docker_java_enabled: true
+splunk_docker_java_version: "21"
+splunk_docker_java_package: "temurin-{{ splunk_docker_java_version }}-jre"
+splunk_docker_java_home: "/usr/lib/jvm/temurin-{{ splunk_docker_java_version }}-jre-amd64"
+
 # Technology Add-ons (TAs) to install
 # TAs must be placed in roles/splunk_docker/files/ as .tar, .tgz, or .spl files
 splunk_docker_unifi_ta_version: 1.0.2+00b9ecb
 splunk_docker_duck_yeah_version: 234
+splunk_docker_dbconnect_version: "421"
 splunk_docker_addons:
   - name: TA-unifi-cloud
     filename: "TA-unifi-cloud-{{ splunk_docker_unifi_ta_version }}.tar"
@@ -96,3 +103,6 @@ splunk_docker_addons:
   - name: Duck Yeah
     filename: "duck-yeah_{{ splunk_docker_duck_yeah_version }}.tgz"
     description: Duck Yeah - Splunk app for packaging and app management
+  - name: Splunk DB Connect
+    filename: "splunk-db-connect_{{ splunk_docker_dbconnect_version }}.tar"
+    description: Splunk DB Connect - database connectivity for Splunk

--- a/roles/splunk_docker/files/README.md
+++ b/roles/splunk_docker/files/README.md
@@ -13,6 +13,7 @@ playbook:
 | ---- | ----------- | ------ |
 | `TA-unifi-cloud-{version}.tar` | UniFi Cloud Add-on | Internal build |
 | `duck-yeah_{version}.tgz` | Duck Yeah Splunk app | Splunkbase |
+| `splunk-db-connect_{version}.tar` | Splunk DB Connect app | Splunkbase |
 
 ## File Versions
 
@@ -20,6 +21,7 @@ Current expected versions (from `defaults/main.yml`):
 
 - `TA-unifi-cloud-1.0.2+00b9ecb.tar`
 - `duck-yeah_234.tgz`
+- `splunk-db-connect_421.tar`
 
 ## Obtaining Files
 
@@ -30,6 +32,10 @@ This is an internal add-on. Contact the infrastructure team for the file.
 ### Duck Yeah
 
 Download from Splunkbase or internal artifact repository.
+
+### Splunk DB Connect
+
+Download from Splunkbase: <https://splunkbase.splunk.com/app/2686>
 
 ## Verification
 

--- a/roles/splunk_docker/tasks/java.yml
+++ b/roles/splunk_docker/tasks/java.yml
@@ -1,0 +1,51 @@
+---
+# Install Adoptium Temurin JRE on the host for Splunk DB Connect.
+# The JRE is bind-mounted read-only into the container and referenced
+# via the JAVA_HOME environment variable set in docker-compose.yml.
+
+- name: Check if Temurin JRE is already installed
+  ansible.builtin.command: "{{ splunk_docker_java_home }}/bin/java -version"
+  register: splunk_docker_java_check
+  changed_when: false
+  failed_when: false
+
+- name: Install Temurin JRE prerequisites
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - curl
+      - gnupg
+    state: present
+    cache_valid_time: 3600
+  when: splunk_docker_java_check.rc != 0
+
+- name: Create Adoptium keyring directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+  when: splunk_docker_java_check.rc != 0
+
+- name: Download Adoptium GPG key
+  ansible.builtin.get_url:
+    url: https://packages.adoptium.net/artifactory/api/gpg/key/public
+    dest: /etc/apt/keyrings/adoptium.asc
+    mode: '0644'
+  when: splunk_docker_java_check.rc != 0
+
+- name: Add Adoptium APT repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch=amd64 signed-by=/etc/apt/keyrings/adoptium.asc]
+      https://packages.adoptium.net/artifactory/deb
+      {{ ansible_distribution_release }} main
+    state: present
+    filename: adoptium
+  when: splunk_docker_java_check.rc != 0
+
+- name: Install Temurin JRE package
+  ansible.builtin.apt:
+    name: "{{ splunk_docker_java_package }}"
+    state: present
+    cache_valid_time: 3600
+  when: splunk_docker_java_check.rc != 0

--- a/roles/splunk_docker/tasks/java.yml
+++ b/roles/splunk_docker/tasks/java.yml
@@ -9,41 +9,54 @@
   changed_when: false
   failed_when: false
 
-- name: Install Temurin JRE
+# Repository setup tasks always run — they are idempotent and cheap.
+# Only the package install is conditional on JRE being absent.
+
+- name: Install Temurin JRE prerequisites
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - curl
+      - gnupg
+    state: present
+    cache_valid_time: 3600
+
+- name: Create Adoptium keyring directory
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download Adoptium GPG key
+  ansible.builtin.get_url:
+    url: https://packages.adoptium.net/artifactory/api/gpg/key/public
+    dest: /etc/apt/keyrings/adoptium.asc
+    mode: '0644'
+    checksum: "sha256:a46d5d3ab75c3c86dddf1bfd2957a067a24b1c6b2d2ed2bc69294bf970c5160b"
+
+- name: Add Adoptium APT repository
+  ansible.builtin.apt_repository:
+    repo: >-
+      deb [arch={{ splunk_docker_java_arch }} signed-by=/etc/apt/keyrings/adoptium.asc]
+      https://packages.adoptium.net/artifactory/deb
+      {{ ansible_distribution_release }} main
+    state: present
+    filename: adoptium
+    update_cache: true
+
+- name: Install Temurin JRE package
   when: splunk_docker_java_check.rc != 0
   block:
-    - name: Install Temurin JRE prerequisites
-      ansible.builtin.apt:
-        name:
-          - ca-certificates
-          - curl
-          - gnupg
-        state: present
-        cache_valid_time: 3600
-
-    - name: Create Adoptium keyring directory
-      ansible.builtin.file:
-        path: /etc/apt/keyrings
-        state: directory
-        mode: '0755'
-
-    - name: Download Adoptium GPG key
-      ansible.builtin.get_url:
-        url: https://packages.adoptium.net/artifactory/api/gpg/key/public
-        dest: /etc/apt/keyrings/adoptium.asc
-        mode: '0644'
-
-    - name: Add Adoptium APT repository
-      ansible.builtin.apt_repository:
-        repo: >-
-          deb [arch=amd64 signed-by=/etc/apt/keyrings/adoptium.asc]
-          https://packages.adoptium.net/artifactory/deb
-          {{ ansible_distribution_release }} main
-        state: present
-        filename: adoptium
-        update_cache: true
-
     - name: Install Temurin JRE package
       ansible.builtin.apt:
         name: "{{ splunk_docker_java_package }}"
         state: present
+        cache_valid_time: 3600
+  rescue:
+    - name: Fail with network guidance
+      ansible.builtin.fail:
+        msg: >-
+          Failed to install {{ splunk_docker_java_package }}.
+          Ensure the host can reach packages.adoptium.net.
+          For air-gapped environments, pre-install the package
+          or configure a local APT mirror.

--- a/roles/splunk_docker/tasks/java.yml
+++ b/roles/splunk_docker/tasks/java.yml
@@ -9,43 +9,41 @@
   changed_when: false
   failed_when: false
 
-- name: Install Temurin JRE prerequisites
-  ansible.builtin.apt:
-    name:
-      - ca-certificates
-      - curl
-      - gnupg
-    state: present
-    cache_valid_time: 3600
+- name: Install Temurin JRE
   when: splunk_docker_java_check.rc != 0
+  block:
+    - name: Install Temurin JRE prerequisites
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - curl
+          - gnupg
+        state: present
+        cache_valid_time: 3600
 
-- name: Create Adoptium keyring directory
-  ansible.builtin.file:
-    path: /etc/apt/keyrings
-    state: directory
-    mode: '0755'
-  when: splunk_docker_java_check.rc != 0
+    - name: Create Adoptium keyring directory
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: '0755'
 
-- name: Download Adoptium GPG key
-  ansible.builtin.get_url:
-    url: https://packages.adoptium.net/artifactory/api/gpg/key/public
-    dest: /etc/apt/keyrings/adoptium.asc
-    mode: '0644'
-  when: splunk_docker_java_check.rc != 0
+    - name: Download Adoptium GPG key
+      ansible.builtin.get_url:
+        url: https://packages.adoptium.net/artifactory/api/gpg/key/public
+        dest: /etc/apt/keyrings/adoptium.asc
+        mode: '0644'
 
-- name: Add Adoptium APT repository
-  ansible.builtin.apt_repository:
-    repo: >-
-      deb [arch=amd64 signed-by=/etc/apt/keyrings/adoptium.asc]
-      https://packages.adoptium.net/artifactory/deb
-      {{ ansible_distribution_release }} main
-    state: present
-    filename: adoptium
-  when: splunk_docker_java_check.rc != 0
+    - name: Add Adoptium APT repository
+      ansible.builtin.apt_repository:
+        repo: >-
+          deb [arch=amd64 signed-by=/etc/apt/keyrings/adoptium.asc]
+          https://packages.adoptium.net/artifactory/deb
+          {{ ansible_distribution_release }} main
+        state: present
+        filename: adoptium
+        update_cache: true
 
-- name: Install Temurin JRE package
-  ansible.builtin.apt:
-    name: "{{ splunk_docker_java_package }}"
-    state: present
-    cache_valid_time: 3600
-  when: splunk_docker_java_check.rc != 0
+    - name: Install Temurin JRE package
+      ansible.builtin.apt:
+        name: "{{ splunk_docker_java_package }}"
+        state: present

--- a/roles/splunk_docker/tasks/main.yml
+++ b/roles/splunk_docker/tasks/main.yml
@@ -58,6 +58,10 @@
     state: started
     enabled: true
 
+- name: Install Java runtime for DB Connect
+  ansible.builtin.include_tasks: java.yml
+  when: splunk_docker_java_enabled
+
 - name: Create Splunk data directories
   ansible.builtin.file:
     path: "{{ item }}"

--- a/roles/splunk_docker/templates/docker-compose.yml.j2
+++ b/roles/splunk_docker/templates/docker-compose.yml.j2
@@ -20,8 +20,8 @@ services:
       # for better separation of concerns and to avoid exposing tokens in container env.
       # Let container entrypoint chown mounted volumes to splunk user at startup
       SPLUNK_HOME_OWNERSHIP_ENFORCEMENT: "true"
-{% if splunk_docker_java_enabled | default(false) %}
-      JAVA_HOME: "{{ splunk_docker_java_home }}"
+{% if splunk_docker_java_enabled %}
+      JAVA_HOME: "{{ splunk_docker_java_container_home }}"
 {% endif %}
     ports:
       - "{{ splunk_docker_web_port }}:8000"
@@ -30,8 +30,8 @@ services:
     volumes:
       - {{ splunk_docker_var_dir }}:/opt/splunk/var
       - {{ splunk_docker_etc_dir }}:/opt/splunk/etc
-{% if splunk_docker_java_enabled | default(false) %}
-      - {{ splunk_docker_java_home }}:{{ splunk_docker_java_home }}:ro
+{% if splunk_docker_java_enabled %}
+      - {{ splunk_docker_java_home }}:{{ splunk_docker_java_container_home }}:ro
 {% endif %}
     restart: unless-stopped
     # Healthcheck uses curl to avoid permission issues with splunk CLI

--- a/roles/splunk_docker/templates/docker-compose.yml.j2
+++ b/roles/splunk_docker/templates/docker-compose.yml.j2
@@ -20,6 +20,9 @@ services:
       # for better separation of concerns and to avoid exposing tokens in container env.
       # Let container entrypoint chown mounted volumes to splunk user at startup
       SPLUNK_HOME_OWNERSHIP_ENFORCEMENT: "true"
+{% if splunk_docker_java_enabled | default(false) %}
+      JAVA_HOME: "{{ splunk_docker_java_home }}"
+{% endif %}
     ports:
       - "{{ splunk_docker_web_port }}:8000"
       - "127.0.0.1:8089:8089"
@@ -27,6 +30,9 @@ services:
     volumes:
       - {{ splunk_docker_var_dir }}:/opt/splunk/var
       - {{ splunk_docker_etc_dir }}:/opt/splunk/etc
+{% if splunk_docker_java_enabled | default(false) %}
+      - {{ splunk_docker_java_home }}:{{ splunk_docker_java_home }}:ro
+{% endif %}
     restart: unless-stopped
     # Healthcheck uses curl to avoid permission issues with splunk CLI
     # The CLI runs as 'ansible' user but needs to read files owned by 'splunk'


### PR DESCRIPTION
## Summary

- Install Adoptium Temurin JRE-21 on the Debian host via APT (mirrors existing Docker APT repo pattern) and bind-mount it read-only into the Splunk container
- Set `JAVA_HOME` env var in docker-compose so DB Connect can locate the JRE
- Deploy Splunk DB Connect 4.2.1 as a standard addon entry via the existing addon mechanism
- Add Java-in-container validation check to `playbooks/validate.yml`

## Changes

| File | Change |
| --- | --- |
| `roles/splunk_docker/defaults/main.yml` | Java variables + DB Connect addon entry |
| `roles/splunk_docker/tasks/java.yml` | New — idempotent Temurin JRE-21 installation via APT |
| `roles/splunk_docker/tasks/main.yml` | Include `java.yml` after Docker service start |
| `roles/splunk_docker/templates/docker-compose.yml.j2` | `JAVA_HOME` env var + JRE bind-mount (both gated on `splunk_docker_java_enabled`) |
| `roles/splunk_docker/files/README.md` | Document DB Connect file requirement |
| `playbooks/validate.yml` | Java-in-container validation check |

## Test plan

- [ ] `pipx run ansible-lint` passes (verified locally — 0 failures)
- [ ] `doppler run -- pipx run ansible-playbook playbooks/site.yml` deploys successfully
- [ ] `doppler run -- pipx run ansible-playbook playbooks/validate.yml` passes including new Java check
- [ ] `docker exec splunk env | grep JAVA_HOME` shows expected path
- [ ] `docker exec splunk /usr/lib/jvm/temurin-21-jre-amd64/bin/java -version` succeeds
- [ ] `ls /opt/splunk/etc/apps/splunk_app_db_connect/` shows DB Connect app deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add JRE-21 installation and Splunk DB Connect support to Splunk Docker setup, with Java validation.
> 
>   - **Java Installation**:
>     - Install Adoptium Temurin JRE-21 via APT in `java.yml`.
>     - Bind-mount JRE into Splunk container in `docker-compose.yml.j2`.
>     - Set `JAVA_HOME` in `docker-compose.yml.j2` if `splunk_docker_java_enabled`.
>   - **Splunk DB Connect**:
>     - Add Splunk DB Connect 4.2.1 to `main.yml` as an addon.
>     - Document DB Connect file requirement in `README.md`.
>   - **Validation**:
>     - Add Java-in-container check to `validate.yml`.
>   - **Misc**:
>     - Include `java.yml` in `main.yml` after Docker service start.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-splunk&utm_source=github&utm_medium=referral)<sup> for 549f509b10567b38d901e28faf88e8fc447e10cc. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->