### PR TITLE
fix: allow all custom indexes in HEC token

### DIFF
--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -20,9 +20,9 @@ splunk_docker_hec_token: ""
 splunk_docker_hec_token_name: splunk_hec_token
 splunk_docker_hec_token_description: "Ansible-managed HEC token for data ingestion"
 splunk_docker_hec_default_index: main
-# Note: despite the pluralized name, this must be a comma-separated string, not a YAML list.
-# Example for multiple indexes: "main,other_index,third_index"
-splunk_docker_hec_indexes: "main,ai,claude,firewall,netflow,network,os,unifi"
+# Dynamically built from splunk_docker_indexes so HEC allowed indexes stay in sync
+# with defined indexes. Always includes 'main' plus all custom index names.
+splunk_docker_hec_indexes: "{{ (['main'] + splunk_docker_indexes | map(attribute='name') | list) | join(',') }}"
 
 # Splunk ports
 splunk_docker_web_port: 8000


### PR DESCRIPTION
## Summary

- Expands `splunk_docker_hec_indexes` from `"main"` to include all custom indexes: `ai`, `claude`, `firewall`, `netflow`, `network`, `os`, `unifi`
- Without this, the HEC token rejects events sent to any non-`main` index, so Cribl Edge data never lands

## Test plan

- [ ] Merge and run `doppler run -- ansible-playbook playbooks/site.yml`
- [ ] Verify in Splunk UI: HEC token allowed indexes shows all custom indexes
- [ ] Confirm data flows from Cribl Edge into the custom indexes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Expands `splunk_docker_hec_indexes` to include custom indexes, allowing HEC token to accept events for these indexes.
> 
>   - **Behavior**:
>     - Expands `splunk_docker_hec_indexes` in `main.yml` from `"main"` to include `ai`, `claude`, `firewall`, `netflow`, `network`, `os`, `unifi`.
>     - Allows HEC token to accept events for these custom indexes, enabling data flow from Cribl Edge.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-splunk&utm_source=github&utm_medium=referral)<sup> for 9e1e04e10a37f9f5e13f06a68f6acdce87b1b34f. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->