### PR TITLE
fix: use include_role in post_tasks so role defaults are available

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -35,4 +35,6 @@
 
   post_tasks:
     - name: Wait for Splunk to be ready after any restarts
-      ansible.builtin.include_tasks: "{{ playbook_dir }}/../roles/splunk_docker/tasks/wait_for_splunk.yml"
+      ansible.builtin.include_role:
+        name: splunk_docker
+        tasks_from: wait_for_splunk


### PR DESCRIPTION
## Summary

`include_tasks` in `post_tasks` doesn't load role defaults, causing `splunk_docker_web_ssl` and `splunk_docker_web_port` to be undefined. Switching to `include_role: tasks_from: wait_for_splunk` loads role defaults automatically.

## Root Cause

When `include_tasks` is called from a playbook `post_tasks` block, it executes in the playbook variable scope, not the role scope. Role `defaults/main.yml` is never loaded. `include_role` with `tasks_from` correctly loads role defaults before executing the task file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Switch from `include_tasks` to `include_role` in `site.yml` to load role defaults and define necessary variables.
> 
>   - **Behavior**:
>     - Switch from `include_tasks` to `include_role` in `post_tasks` of `site.yml` to load role defaults.
>     - Ensures `splunk_docker_web_ssl` and `splunk_docker_web_port` are defined.
>   - **Root Cause**:
>     - `include_tasks` does not load role defaults, causing undefined variables.
>     - `include_role` with `tasks_from` loads defaults before executing tasks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-splunk&utm_source=github&utm_medium=referral)<sup> for ecf69bb7d75285786a4cce205022fd1d7d33bcfb. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->