### PR TITLE
test: fix molecule verify firewall condition and add content assertions

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -45,9 +45,9 @@ jobs:
         run: |
           ansible-galaxy collection list
 
-      - name: Run molecule syntax check
+      - name: Run molecule tests
         run: |
-          molecule syntax
+          molecule test
         env:
           PY_COLORS: "1"
           ANSIBLE_FORCE_COLOR: "1"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -36,6 +36,9 @@ provisioner:
         # Test values for molecule - override in production
         splunk_docker_password: "molecule-test-password"
         splunk_docker_hec_token: "molecule-test-hec-token"
+        # TA binaries are gitignored (placed manually at deploy time).
+        # Skip installation in CI.
+        splunk_docker_addons: []
   env:
     SPLUNK_DOCKER_PASSWORD: "molecule-test-password"
     SPLUNK_DOCKER_HEC_TOKEN: "molecule-test-hec-token"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -33,3 +33,19 @@
           - python3-requests
         state: present
       when: ansible_os_family == 'Debian'
+
+    # Docker-in-Docker on GitHub Actions (Ubuntu 24.04) cannot use overlayfs
+    # to convert whiteout files even in privileged containers — EPERM from mknod.
+    # Pre-creating daemon.json with vfs storage driver before Docker is installed
+    # ensures the daemon starts with vfs on first run.
+    - name: Ensure /etc/docker directory exists
+      ansible.builtin.file:
+        path: /etc/docker
+        state: directory
+        mode: '0755'
+
+    - name: Configure Docker daemon to use vfs storage driver
+      ansible.builtin.copy:
+        dest: /etc/docker/daemon.json
+        content: '{"storage-driver": "vfs"}'
+        mode: '0644'

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -73,12 +73,14 @@
       ansible.builtin.stat:
         path: "{{ splunk_docker_config_dir }}/firewall.sh"
       register: firewall_script
+      when: splunk_docker_firewall_enabled | default(false)
 
     - name: Assert firewall script configured
       ansible.builtin.assert:
         that:
           - firewall_script.stat.exists
         fail_msg: "firewall.sh not found - firewall not configured"
+      when: splunk_docker_firewall_enabled | default(false)
 
     - name: Check Splunk apps directory exists
       ansible.builtin.stat:
@@ -91,3 +93,29 @@
           - apps_dir.stat.exists
           - apps_dir.stat.isdir
         fail_msg: "Splunk apps directory not found"
+
+    - name: Read indexes.conf content
+      ansible.builtin.slurp:
+        src: "{{ splunk_docker_etc_dir }}/system/local/indexes.conf"
+      register: indexes_content
+
+    - name: Verify all pipeline indexes are configured
+      ansible.builtin.assert:
+        that:
+          - "'[unifi]' in (indexes_content.content | b64decode)"
+          - "'[netflow]' in (indexes_content.content | b64decode)"
+          - "'[firewall]' in (indexes_content.content | b64decode)"
+          - "'[network]' in (indexes_content.content | b64decode)"
+          - "'[os]' in (indexes_content.content | b64decode)"
+        fail_msg: "One or more pipeline indexes missing from indexes.conf"
+
+    - name: Read docker-compose.yml content
+      ansible.builtin.slurp:
+        src: "{{ splunk_docker_config_dir }}/docker-compose.yml"
+      register: compose_content
+
+    - name: Verify HEC port is mapped
+      ansible.builtin.assert:
+        that:
+          - "'8088:8088' in (compose_content.content | b64decode)"
+        fail_msg: "HEC port 8088:8088 not found in docker-compose.yml"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -107,6 +107,8 @@
           - "'[firewall]' in (indexes_content.content | b64decode)"
           - "'[network]' in (indexes_content.content | b64decode)"
           - "'[os]' in (indexes_content.content | b64decode)"
+          - "'[ai]' in (indexes_content.content | b64decode)"
+          - "'[claude]' in (indexes_content.content | b64decode)"
         fail_msg: "One or more pipeline indexes missing from indexes.conf"
 
     - name: Read docker-compose.yml content
@@ -115,7 +117,9 @@
       register: compose_content
 
     - name: Verify HEC port is mapped
+      vars:
+        compose_data: "{{ compose_content.content | b64decode | from_yaml }}"
       ansible.builtin.assert:
         that:
-          - "'8088:8088' in (compose_content.content | b64decode)"
+          - "'8088:8088' in compose_data.services.splunk.ports"
         fail_msg: "HEC port 8088:8088 not found in docker-compose.yml"


### PR DESCRIPTION
## Summary

- Fix latent bug in `molecule/default/verify.yml`: `firewall.sh` existence check was unconditional but firewall is disabled by default (`splunk_docker_firewall_enabled: false`). Now gated on `when: splunk_docker_firewall_enabled | default(false)`
- Add `indexes.conf` content assertions verifying all pipeline indexes are configured: `[unifi]`, `[netflow]`, `[firewall]`, `[network]`, `[os]`
- Add `docker-compose.yml` HEC port assertion (`8088:8088`)
- Upgrade `molecule syntax` → `molecule test` in CI so the full test suite runs

## Test plan

- [x] Pre-commit hooks pass (ansible-lint, yaml, markdownlint)
- [ ] `molecule test` passes locally
- [ ] CI molecule job passes on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes firewall condition bug and adds content assertions in `verify.yml`, updates CI to run full Molecule test suite.
> 
>   - **Behavior**:
>     - Fixes bug in `verify.yml` by adding condition `when: splunk_docker_firewall_enabled | default(false)` to `firewall.sh` existence check.
>     - Adds assertions in `verify.yml` to check `indexes.conf` for `[unifi]`, `[netflow]`, `[firewall]`, `[network]`, `[os]`.
>     - Adds assertion in `verify.yml` to check `docker-compose.yml` for HEC port `8088:8088`.
>   - **CI**:
>     - Changes CI workflow in `molecule.yml` from `molecule syntax` to `molecule test` to run full test suite.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=JacobPEvans%2Fansible-splunk&utm_source=github&utm_medium=referral)<sup> for 5b4f95d11bc11b144f322ca34737b031610b1c8c. You can [customize](https://app.ellipsis.dev/JacobPEvans/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->