### PR TITLE
chore: gitignore /result nix build output symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,12 @@ inventory/terraform_inventory.json
 # Nix direnv cache
 .direnv/
 
+# Nix build output symlinks — `nix build` and some dev-shell refreshes
+# leave `result` (and multi-output variants like `result-1`, `result-bin`,
+# `result-dev`) at the repo root pointing into /nix/store. Never commit
+# them; re-created on every build.
+/result*
+
 # Private AI assistant instructions (not committed to git)
 .CLAUDE.local.md
 CLAUDE.local.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0](https://github.com/JacobPEvans/ansible-splunk/compare/v0.9.0...v0.10.0) (2026-04-11)
 
-
 ### Features
 
 * **splunk:** MinIO add-on registry + Splunkbase auto-sync ([7364448](https://github.com/JacobPEvans/ansible-splunk/commit/736444891f658d374e85329b5fecb47cc5612a9d))


### PR DESCRIPTION
## Summary

Adds `/result` to `.gitignore`. Nix build creates a `result` symlink at the repo root pointing into `/nix/store`, and nix-direnv / dev-shell refreshes sometimes regenerate it. It's ephemeral, never belongs in git, but kept showing up as untracked in `git status` on nix-based workstations.

## Why

`nix build` and dev-shell flake evaluations drop a `result` symlink at the invocation directory by default. On this repo's worktree that lands next to `CLAUDE.md`, and every `git status` thereafter has one line of noise. The symlink is rebuilt on every invocation, so there is no value in tracking it.

## Changes

- `.gitignore` — added `/result` with a 3-line comment block explaining the source and why it's safe to ignore

## Test plan

- [x] Verified the untracked `result` file on main was a symlink into `/nix/store/s3b8pb3cgr2m4g4p36qln1g6x7hmc13f-nix-shell` (classic nix-shell result)
- [x] `git check-ignore -v result` confirms the new pattern catches it
- [x] No functional change — pure ignore rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)