### PR TITLE
fix: add automation bots to AI Moderator skip-bots

### DIFF
--- a/.github/workflows/ai-moderator.lock.yml
+++ b/.github/workflows/ai-moderator.lock.yml
@@ -1004,7 +1004,7 @@ jobs:
         id: check_skip_bots
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
-          GH_AW_SKIP_BOTS: "github-actions,copilot"
+          GH_AW_SKIP_BOTS: "github-actions,copilot,renovate,dependabot,release-please,jacobpevans-github-actions"
           GH_AW_WORKFLOW_NAME: "AI Moderator"
         with:
           script: |

--- a/.github/workflows/ai-moderator.md
+++ b/.github/workflows/ai-moderator.md
@@ -14,7 +14,7 @@ on:
     types: [opened]
     forks: "*"
   skip-roles: [admin, maintainer, write, triage]
-  skip-bots: [github-actions, copilot]
+  skip-bots: [github-actions, copilot, renovate, dependabot, release-please, jacobpevans-github-actions]
 permissions:
   contents: read
   issues: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.2](https://github.com/JacobPEvans/ansible-splunk/compare/v0.11.1...v0.11.2) (2026-04-13)
 
-
 ### Bug Fixes
 
 * **gh-aw:** recompile agentic workflow lock files with v0.68.1 ([d83f93c](https://github.com/JacobPEvans/ansible-splunk/commit/d83f93c7509937fa3ea53b308cfc7b8728601aae))


### PR DESCRIPTION
Adds \`renovate\`, \`dependabot\`, \`release-please\`, and \`jacobpevans-github-actions\` to the AI Moderator \`skip-bots\` list.

These automation bots have \`permission: none\` on repositories (GitHub App model), so the role-based skip doesn't catch them. Without this fix, every Renovate/Dependabot/release-please PR triggers a full AI agent run.

Changes:
- \`.github/workflows/ai-moderator.md\`: updated \`skip-bots\` frontmatter
- \`.github/workflows/ai-moderator.lock.yml\`: updated \`GH_AW_SKIP_BOTS\` env var