### PR TITLE
fix: add bot PR CI retrigger workflow

### DIFF
--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -7,9 +7,9 @@ name: Retrigger PR Checks
 
 on:
   schedule:
-    - cron: "0 10 * * *"  # 6 AM ET (UTC-4)
-    - cron: "0 20 * * *"  # 4 PM ET (UTC-4)
-    - cron: "0 0 * * *"   # 8 PM ET (UTC-4)
+    - cron: "0 10 * * *"  # 6 AM EDT
+    - cron: "0 20 * * *"  # 4 PM EDT
+    - cron: "0 0 * * *"   # 8 PM EDT
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/retrigger-pr-checks.yml
+++ b/.github/workflows/retrigger-pr-checks.yml
@@ -1,0 +1,24 @@
+---
+name: Retrigger PR Checks
+
+# Ensures bot-created PRs (GITHUB_TOKEN) get the Merge Gate check.
+# Calls shared logic from JacobPEvans/.github.
+# See: .github/workflows/_retrigger-pr-checks.yml in JacobPEvans/.github
+
+on:
+  schedule:
+    - cron: "0 10 * * *"  # 6 AM ET (UTC-4)
+    - cron: "0 20 * * *"  # 4 PM ET (UTC-4)
+    - cron: "0 0 * * *"   # 8 PM ET (UTC-4)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  retrigger:
+    uses: JacobPEvans/.github/.github/workflows/_retrigger-pr-checks.yml@main
+    secrets:
+      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.11.3](https://github.com/JacobPEvans/ansible-splunk/compare/v0.11.2...v0.11.3) (2026-04-13)
 
-
 ### Bug Fixes
 
 * add automation bots to AI Moderator skip-bots ([#152](https://github.com/JacobPEvans/ansible-splunk/issues/152)) ([7bbd048](https://github.com/JacobPEvans/ansible-splunk/commit/7bbd0482ab672e0efab0f6e1db14e09a579d2ffc))


### PR DESCRIPTION
## Summary

- Bot-created PRs (Copilot link-checker, agentic workflows) use `GITHUB_TOKEN` → no `pull_request` event → `ci-gate.yml` never runs → **Merge Gate** missing → PR blocked
- Currently blocking: #159, #163, #164, #166

Adds `retrigger-pr-checks.yml` — a thin caller to the shared `JacobPEvans/.github` reusable workflow that runs 3×/day (6 AM, 4 PM, 8 PM ET) to close/reopen bot PRs missing CI Gate runs, triggering `ci-gate.yml` via `pull_request: reopened`.

## Dependencies

Requires JacobPEvans/.github#207 merged first (provides the shared `_retrigger-pr-checks.yml`).

## Test plan

- [ ] Merge JacobPEvans/.github#207 first
- [ ] Merge this PR
- [ ] Run `gh workflow run retrigger-pr-checks.yml --repo JacobPEvans/ansible-splunk`
- [ ] Verify PR #166 closes/reopens → CI Gate fires → Merge Gate appears → unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)