### PR TITLE
feat(splunk_docker): add mac_perf index

### DIFF
--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -1,3 +1,4 @@
+---
 name: gh-aw pin refresh
 
 on:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -111,6 +111,7 @@
           - "'[ai]' in (indexes_content.content | b64decode)"
           - "'[claude]' in (indexes_content.content | b64decode)"
           - "'[gemini]' in (indexes_content.content | b64decode)"
+          - "'[mac_perf]' in (indexes_content.content | b64decode)"
           - "'[openai]' in (indexes_content.content | b64decode)"
           - "'[vscode]' in (indexes_content.content | b64decode)"
         fail_msg: "One or more pipeline indexes missing from indexes.conf"

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -79,6 +79,9 @@ splunk_docker_indexes:
   - name: gemini
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"
+  - name: mac_perf
+    max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
+    frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"
   - name: netflow
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"


### PR DESCRIPTION
## Summary

- ✨ Add `mac_perf` index to `splunk_docker_indexes` (alphabetically between `gemini` and `netflow`).
- 🔑 HEC token auto-derives via `uuidv5(HEC_NAMESPACE, "splunk-hec-mac_perf")` in `playbooks/site.yml` (and `playbooks/validate.yml`) — `roles/splunk_docker/templates/inputs.conf.j2` consumes the resulting `splunk_docker_hec_token_values` map, so no template change is needed.
- ✅ Add `mac_perf` to `molecule/default/verify.yml` indexes.conf assertions (alphabetical between `gemini` and `openai`).
- 🩹 Drive-by: prepend missing `---` document-start header to `.github/workflows/gh-aw-pin-refresh.yml` (pre-existing ansible-lint failure on main blocking all commits).

## Companion PR

- [JacobPEvans/cc-edge-the-mac-pack-io#6](https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/pull/6) — pack v0.2.0 routes `macos:perf:snapshot` + `macos:perf:powermetrics` to this index.

## Test plan

- [ ] CI: ansible-lint, yamllint, hooks pass
- [ ] Molecule verify asserts `[mac_perf]` stanza in indexes.conf
- [ ] After merge: run `doppler run -- ansible-playbook playbooks/configure_indexes.yml` to provision the index and render the per-index HEC token
- [ ] Capture rendered `mac_perf` HEC token for use in Cribl Edge destination configuration

(claude)