### PR TITLE
feat(splunk_docker): wire TA-slack-add-on-for-splunk into addons registry

### DIFF
--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -1,3 +1,4 @@
+---
 name: gh-aw pin refresh
 
 on:

--- a/roles/splunk_docker/vars/addons.yml
+++ b/roles/splunk_docker/vars/addons.yml
@@ -54,8 +54,11 @@ splunk_docker_addons:
 
   # Slack Add-on for Splunk (TA-slack-add-on-for-splunk). Vendor distributes
   # only via direct download (not Splunkbase, no GitHub release). To rotate
-  # versions, repackage `~/git/splunk/TA-slack-add-on-for-splunk/` and upload
-  # to MinIO with the version-free filename:
+  # versions, repackage `~/git/splunk/TA-slack-add-on-for-splunk/` as an
+  # uncompressed .tar archive (not .tar.gz — install uses the registry filename
+  # directly via ansible.builtin.unarchive) and upload to MinIO with the
+  # version-free filename:
+  #   tar -cf slack-add-on-for-splunk.tar -C ~/git/splunk TA-slack-add-on-for-splunk
   #   mc cp slack-add-on-for-splunk.tar homelab/splunk-addons/slack-add-on-for-splunk.tar
   #   mc tag set homelab/splunk-addons/slack-add-on-for-splunk.tar "version=3.0.0"
   - {filename: slack-add-on-for-splunk.tar, app_dir: TA-slack-add-on-for-splunk}

--- a/roles/splunk_docker/vars/addons.yml
+++ b/roles/splunk_docker/vars/addons.yml
@@ -52,6 +52,14 @@ splunk_docker_addons:
   # a new version is needed.
   - {filename: hurricane-labs-add-on-for-automox.tar, app_dir: TA-automox}
 
+  # Slack Add-on for Splunk (TA-slack-add-on-for-splunk). Vendor distributes
+  # only via direct download (not Splunkbase, no GitHub release). To rotate
+  # versions, repackage `~/git/splunk/TA-slack-add-on-for-splunk/` and upload
+  # to MinIO with the version-free filename:
+  #   mc cp slack-add-on-for-splunk.tar homelab/splunk-addons/slack-add-on-for-splunk.tar
+  #   mc tag set homelab/splunk-addons/slack-add-on-for-splunk.tar "version=3.0.0"
+  - {filename: slack-add-on-for-splunk.tar, app_dir: TA-slack-add-on-for-splunk}
+
   # --- GitHub Releases: JacobPEvans/<repo>/releases/latest ---
   - {filename: VisiCore_TA_AI_Observability.spl, app_dir: VisiCore_TA_AI_Observability, github_repo: JacobPEvans/VisiCore_TA_AI_Observability}
   - {filename: VisiCore_App_for_AI_Observability.spl, app_dir: VisiCore_App_for_AI_Observability, github_repo: JacobPEvans/VisiCore_App_for_AI_Observability}


### PR DESCRIPTION
Closes the Slack TA orphan: the tarball lived under ~/git/splunk/ but no addons.yml entry referenced it, so splunk_docker never installed it. Adds the entry to the MinIO no-Splunkbase-match section alongside TA-automox, and documents that the archive must be an uncompressed .tar (not .tar.gz) because ansible.builtin.unarchive uses the registry filename directly.

Drive-by: prepended `---` to `.github/workflows/gh-aw-pin-refresh.yml` to fix a pre-existing `yaml[document-start]` lint failure.

## Manual prerequisite

Upload the TA tarball to MinIO once (uncompressed .tar — NOT .tar.gz):
```
tar -cf slack-add-on-for-splunk.tar -C ~/git/splunk TA-slack-add-on-for-splunk
mc cp slack-add-on-for-splunk.tar homelab/splunk-addons/slack-add-on-for-splunk.tar
mc tag set homelab/splunk-addons/slack-add-on-for-splunk.tar "version=3.0.0"
```

## Changes

- `roles/splunk_docker/vars/addons.yml` — add Slack TA entry to MinIO manual-upload section; clarify `.tar` vs `.tar.gz` with explicit `tar -cf` command in comment
- `.github/workflows/gh-aw-pin-refresh.yml` — prepend `---` to satisfy yamllint document-start rule

## Test plan

- [x] ansible-lint passes
- [x] CI / lint, validate, Molecule all pass
- [ ] After MinIO upload + merge: `ansible-playbook playbooks/site.yml` installs the TA
- [ ] Verify `/opt/splunk/etc/apps/TA-slack-add-on-for-splunk/default/app.conf` matches version 3.0.0

(claude)