### PR TITLE
chore: remove deprecated GH_ACTION_JACOBPEVANS_APP_ID from workflow callers

### DIFF
--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -30,5 +30,4 @@ jobs:
     with:
       operation: ${{ inputs.operation || 'compile' }}
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,5 +14,4 @@ jobs:
       pull-requests: write
     uses: JacobPEvans/.github/.github/workflows/_release-please.yml@main
     secrets:
-      GH_ACTION_JACOBPEVANS_APP_ID: ${{ secrets.GH_ACTION_JACOBPEVANS_APP_ID }}
       GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.12.0](https://github.com/JacobPEvans/ansible-splunk/compare/v0.11.9...v0.12.0) (2026-05-03)
 
-
 ### Features
 
 * **splunk_docker:** add mac_perf index ([#184](https://github.com/JacobPEvans/ansible-splunk/issues/184)) ([6acc906](https://github.com/JacobPEvans/ansible-splunk/commit/6acc9069266771e24050f79f2eedb2e1aaa3303c))
 * **splunk_docker:** wire TA-slack-add-on-for-splunk into addons registry ([#186](https://github.com/JacobPEvans/ansible-splunk/issues/186)) ([f93e5e0](https://github.com/JacobPEvans/ansible-splunk/commit/f93e5e01b8d2f1c763d1740c9454e61a0e7fa05b))
-
 
 ### Bug Fixes
 
 * **deps:** refresh gh-aw action SHA pins ([#188](https://github.com/JacobPEvans/ansible-splunk/issues/188)) ([a884904](https://github.com/JacobPEvans/ansible-splunk/commit/a884904cd6cf006d5e8437b44fb65e7c2e8e65fa))
 
 ## [0.11.9](https://github.com/JacobPEvans/ansible-splunk/compare/v0.11.8...v0.11.9) (2026-04-29)
-
 
 ### Bug Fixes
 


### PR DESCRIPTION
## Summary
- Removes `GH_ACTION_JACOBPEVANS_APP_ID` from `secrets:` passthrough in release-please and gh-aw-pin-refresh callers
- Central reusable workflows now read GitHub App Client ID directly from vars (no secrets passthrough needed)

**Merge order:** secrets-sync#74 → .github#268 → consumer PRs

## Changes
- .github/workflows/gh-aw-pin-refresh.yml
- .github/workflows/release-please.yml
- CHANGELOG.md

## Test Plan
- [ ] Verify .github#268 merged first
- [ ] Verify `GH_APP_CLIENT_ID` is available in vars on this repo (synced by secrets-sync)
- [ ] Trigger release-please workflow — confirm no deprecation warnings in run logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)