### PR TITLE
chore(claude): enable scoped plugins via .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "enabledPlugins": {
+    "ansible-workflows@lunar-claude": true
+  }
+}


### PR DESCRIPTION
## Summary

Per-repo override for Claude Code plugin scoping ([nix-ai #721](https://github.com/JacobPEvans/nix-ai/pull/721)).

`ansible-workflows@lunar-claude` is now disabled at user level in `nix-ai` to keep the global Claude Code skill-listing budget under the 1% default. This adds a project-scoped `.claude/settings.json` so the plugin(s) reload automatically inside this worktree (Claude Code deep-merges project settings on top of user settings).

## Test plan

- [ ] Fresh Claude Code session inside this repo → `/skills` lists `ansible-workflows` plugin
- [ ] Fresh Claude Code session inside an unrelated repo (e.g. `nix-ai`) → those plugins are NOT listed