### PR TITLE
feat(splunk_docker): add mac_perf index for macOS perf telemetry

### DIFF
--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -1,3 +1,4 @@
+---
 name: gh-aw pin refresh
 
 on:

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -111,6 +111,7 @@
           - "'[ai]' in (indexes_content.content | b64decode)"
           - "'[claude]' in (indexes_content.content | b64decode)"
           - "'[gemini]' in (indexes_content.content | b64decode)"
+          - "'[mac_perf]' in (indexes_content.content | b64decode)"
           - "'[openai]' in (indexes_content.content | b64decode)"
           - "'[vscode]' in (indexes_content.content | b64decode)"
         fail_msg: "One or more pipeline indexes missing from indexes.conf"

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -79,6 +79,9 @@ splunk_docker_indexes:
   - name: gemini
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"
+  - name: mac_perf
+    max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
+    frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"
   - name: netflow
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"


### PR DESCRIPTION
Abandoned local work surfaced by workspace sweep 2026-05-22. Review and rebase before merging.