### PR TITLE
fix(pre-commit): exclude release-please CHANGELOG.md from markdownlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,4 +35,4 @@ repos:
     hooks:
       - id: markdownlint
         args: [--config, .markdownlint.json, --fix]
-        exclude: ^\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))
+        exclude: ^(\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))|CHANGELOG\.md$)


### PR DESCRIPTION
Mirrors the canonical fix from [JacobPEvans/ansible-proxmox#201](https://github.com/JacobPEvans/ansible-proxmox/pull/201) (which closes [JacobPEvans/ansible-proxmox#200](https://github.com/JacobPEvans/ansible-proxmox/issues/200)).

## Problem

The `markdownlint` pre-commit hook (`igorshubovych/markdownlint-cli`) fails on `CHANGELOG.md`, which release-please auto-generates with formatting that violates this project's markdownlint rules:

- `MD012/no-multiple-blanks`: release-please inserts two blank lines between version sections.
- `MD013/line-length`: commit/PR links routinely exceed 160 chars.

This hook also runs with `--fix`, so each commit silently rewrites `CHANGELOG.md` and strips the release-please blank lines — only to have the next release-please run reintroduce them. The result is unrelated CHANGELOG churn on every PR and an eventual hook failure once `--fix` cannot resolve every rule.

## Fix

Extend the existing `exclude` regex on the `markdownlint` hook to also match `CHANGELOG.md`:

```yaml
exclude: ^(\.github/(aw/|workflows/(.*\.lock\.yml|agentics-maintenance\.yml))|CHANGELOG\.md$)
```

The repo's existing `exclude` was wider than `ansible-proxmox`'s (it already skipped agentics/workflow lock files), so the regex union preserves all existing skips and adds `CHANGELOG.md`.

## Verification

```text
$ pre-commit run markdownlint --files CHANGELOG.md
markdownlint.........................................(no files to check)Skipped

$ pre-commit run markdownlint --files README.md
markdownlint.............................................................Passed
```

## Test plan

- [x] `pre-commit run markdownlint --files CHANGELOG.md` correctly skips
- [x] `pre-commit run markdownlint --files README.md` still runs and passes (no regression)
- [x] Commit is GPG-signed