### PR TITLE
chore: audit cleanup pass (2026-05-22)

### DIFF
--- a/.github/workflows/gh-aw-pin-refresh.yml
+++ b/.github/workflows/gh-aw-pin-refresh.yml
@@ -1,3 +1,4 @@
+---
 name: gh-aw pin refresh
 
 on:

--- a/playbooks/sync-splunkbase.yml
+++ b/playbooks/sync-splunkbase.yml
@@ -160,7 +160,7 @@
 
     - name: Authenticate to Splunkbase
       ansible.builtin.uri:
-        url: https://splunkbase.splunk.com/api/account:login/
+        url: "{{ splunkbase_api_url | default('https://splunkbase.splunk.com') }}/api/account:login/"
         method: POST
         body_format: form-urlencoded
         body:
@@ -191,7 +191,7 @@
     - name: Download drifted entries from Splunkbase
       ansible.builtin.get_url:
         url: >-
-          https://splunkbase.splunk.com/app/{{ item.splunkbase_id }}/release/{{ item.version }}/download/
+          {{ splunkbase_api_url | default('https://splunkbase.splunk.com') }}/app/{{ item.splunkbase_id }}/release/{{ item.version }}/download/
         dest: "{{ splunkbase_sync_tmpdir }}/{{ item.filename }}"
         headers:
           X-Auth-Token: "{{ splunkbase_token }}"

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -15,6 +15,11 @@ splunk_docker_container_name: splunk
 # Splunk credentials (from Doppler) - set in playbook vars
 splunk_docker_password: ""
 
+# Splunk General Terms acceptance string for SPLUNK_GENERAL_TERMS env var.
+# Override in staging to point at non-prod terms acceptance strings if Splunk
+# publishes a new SGT version mid-release cycle.
+splunk_docker_sgt_accept: "--accept-sgt-current-at-splunk-com"
+
 # HEC token values — dict of { index_name: token_uuid }.
 # When HEC_NAMESPACE is set, per-index tokens are derived via uuidv5.
 # SPLUNK_HEC_TOKEN provides the shared legacy fallback.

--- a/roles/splunk_docker/meta/main.yml
+++ b/roles/splunk_docker/meta/main.yml
@@ -1,0 +1,16 @@
+---
+# splunk_docker role metadata
+
+galaxy_info:
+  role_name: splunk_docker
+  author: JacobPEvans
+  description: Deploy Splunk Enterprise via Docker
+  license: MIT
+  min_ansible_version: "2.17"
+
+  platforms:
+    - name: Debian
+      versions:
+        - bookworm
+
+dependencies: []

--- a/roles/splunk_docker/templates/docker-compose.yml.j2
+++ b/roles/splunk_docker/templates/docker-compose.yml.j2
@@ -13,7 +13,7 @@ services:
     container_name: {{ splunk_docker_container_name }}
     environment:
       SPLUNK_START_ARGS: "--accept-license"
-      SPLUNK_GENERAL_TERMS: "{{ splunk_docker_sgt_accept | default('--accept-sgt-current-at-splunk-com') }}"
+      SPLUNK_GENERAL_TERMS: "{{ splunk_docker_sgt_accept }}"
       SPLUNK_PASSWORD: "{{ splunk_docker_password }}"
       # HEC tokens are managed via inputs.conf (deployed by Ansible), not the
       # Docker entrypoint. Passing SPLUNK_HEC_TOKEN here causes the entrypoint's

--- a/roles/splunk_docker/templates/docker-compose.yml.j2
+++ b/roles/splunk_docker/templates/docker-compose.yml.j2
@@ -13,7 +13,7 @@ services:
     container_name: {{ splunk_docker_container_name }}
     environment:
       SPLUNK_START_ARGS: "--accept-license"
-      SPLUNK_GENERAL_TERMS: "--accept-sgt-current-at-splunk-com"
+      SPLUNK_GENERAL_TERMS: "{{ splunk_docker_sgt_accept | default('--accept-sgt-current-at-splunk-com') }}"
       SPLUNK_PASSWORD: "{{ splunk_docker_password }}"
       # HEC tokens are managed via inputs.conf (deployed by Ansible), not the
       # Docker entrypoint. Passing SPLUNK_HEC_TOKEN here causes the entrypoint's


### PR DESCRIPTION
Omnibus cleanup PR from the 2026-05-22 home lab audit.

## Changes
1. Parameterized SPLUNK_GENERAL_TERMS (allows staging override of license acceptance string)
2. Parameterized splunkbase_api_url (allows pointing at stage.splunkbase for tests)
3. Added meta/main.yml for splunk_docker role
4. Added YAML document start to gh-aw-pin-refresh.yml workflow (unblocks pre-commit; pre-existing lint failure on main)

## Deferred to org-wide trackers
- RunsOn v3 migration on _ci.yml + _molecule.yml — JacobPEvans/terraform-proxmox#307
- Role README backfill — JacobPEvans/ansible-proxmox#202

## Related trackers
- JacobPEvans/ansible-proxmox#202 Ansible role standards
- JacobPEvans/terraform-proxmox#307 RunsOn v3 migration