### PR TITLE
feat(splunk): add macOS Cribl Edge silence-detector saved search

### DIFF
--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -15,6 +15,12 @@ splunk_docker_container_name: splunk
 # Splunk credentials (from Doppler) - set in playbook vars
 splunk_docker_password: ""
 
+# Destination for saved-search alert emails. Override per-inventory or
+# per-playbook. Empty string disables email delivery on the matched alert
+# (the saved search still runs and surfaces in the Splunk UI's Triggered
+# Alerts panel — only the email action is no-op'd).
+splunk_docker_alert_email: ""
+
 # Splunk General Terms acceptance string for SPLUNK_GENERAL_TERMS env var.
 # Override in staging to point at non-prod terms acceptance strings if Splunk
 # publishes a new SGT version mid-release cycle.

--- a/roles/splunk_docker/tasks/main.yml
+++ b/roles/splunk_docker/tasks/main.yml
@@ -151,6 +151,15 @@
     mode: '0644'
   notify: Restart Splunk container
 
+- name: Deploy savedsearches.conf for pipeline-silence alerts
+  ansible.builtin.template:
+    src: savedsearches.conf.j2
+    dest: "{{ splunk_docker_etc_dir }}/system/local/savedsearches.conf"
+    owner: "{{ splunk_docker_user }}"
+    group: "{{ splunk_docker_group }}"
+    mode: '0644'
+  notify: Restart Splunk container
+
 - name: Check if Splunk Docker image exists
   community.docker.docker_image_info:
     name: "{{ splunk_docker_image }}"

--- a/roles/splunk_docker/templates/savedsearches.conf.j2
+++ b/roles/splunk_docker/templates/savedsearches.conf.j2
@@ -11,7 +11,11 @@
 [macos_edge_silence_detector]
 description = Alerts when the macbook-m4 Cribl Edge -> Cribl Cloud -> Splunk chain has been silent for more than 15 minutes. Catches Mac offline, daemon crash, Cribl Cloud enrollment expiry, Stream pipeline stalls, and HEC ingestion failures with a single signal.
 search = | tstats latest(_time) as last_seen WHERE (index=os OR index=mac_perf) sourcetype=macos:* | eval minutes_silent = (now() - last_seen) / 60 | where minutes_silent > 15
-dispatch.earliest_time = -30m
+# Lookback must exceed the worst-case silence the alert needs to detect.
+# A short window (e.g. -30m) starves tstats of data once silence exceeds
+# the window, so the alert silently stops firing exactly when it matters
+# most. tstats reads only indexed metadata, so a wide window is cheap.
+dispatch.earliest_time = -24h
 dispatch.latest_time = now
 cron_schedule = */5 * * * *
 enableSched = 1
@@ -24,7 +28,9 @@ alert.track = 1
 counttype = number of events
 relation = greater than
 quantity = 0
+{% if splunk_docker_alert_email %}
 action.email = 1
 action.email.to = {{ splunk_docker_alert_email }}
 action.email.subject = [Splunk Alert] macOS Cribl Edge chain silent
 action.email.message.alert = The macbook-m4 Cribl Edge pipeline has not delivered any macos:* sourcetype events to Splunk in the last 15+ minutes. Investigate Cribl Edge daemon, Cribl Cloud enrollment, Cribl Stream pipelines, and Splunk HEC ingestion.
+{% endif %}

--- a/roles/splunk_docker/templates/savedsearches.conf.j2
+++ b/roles/splunk_docker/templates/savedsearches.conf.j2
@@ -1,0 +1,30 @@
+{# Splunk saved searches (alerts).
+
+   Currently scoped to pipeline-silence detection. Each saved search runs
+   on a cron and fires when its tstats search returns >0 results (i.e. a
+   monitored host has gone quiet beyond the threshold).
+
+   Wired into the system/local stanza so the alerts run under the system
+   namespace and don't depend on any specific Splunk app being installed.
+#}
+
+[macos_edge_silence_detector]
+description = Alerts when the macbook-m4 Cribl Edge -> Cribl Cloud -> Splunk chain has been silent for more than 15 minutes. Catches Mac offline, daemon crash, Cribl Cloud enrollment expiry, Stream pipeline stalls, and HEC ingestion failures with a single signal.
+search = | tstats latest(_time) as last_seen WHERE (index=os OR index=mac_perf) sourcetype=macos:* | eval minutes_silent = (now() - last_seen) / 60 | where minutes_silent > 15
+dispatch.earliest_time = -30m
+dispatch.latest_time = now
+cron_schedule = */5 * * * *
+enableSched = 1
+is_visible = 1
+disabled = 0
+alert.severity = 3
+alert.suppress = 1
+alert.suppress.period = 60m
+alert.track = 1
+counttype = number of events
+relation = greater than
+quantity = 0
+action.email = 1
+action.email.to = {{ splunk_docker_alert_email }}
+action.email.subject = [Splunk Alert] macOS Cribl Edge chain silent
+action.email.message.alert = The macbook-m4 Cribl Edge pipeline has not delivered any macos:* sourcetype events to Splunk in the last 15+ minutes. Investigate Cribl Edge daemon, Cribl Cloud enrollment, Cribl Stream pipelines, and Splunk HEC ingestion.


### PR DESCRIPTION
## Summary

Adds a single Splunk saved search (`macos_edge_silence_detector`) that fires when the `macbook-m4 → Cribl Cloud → Cribl Stream → Splunk` chain has been silent for more than 15 minutes. This is **Phase G** of the Cribl Mac monitoring lockdown plan.

A single signal catches: Mac offline, Cribl Edge daemon crash, Cribl Cloud enrollment expiry, Cribl Stream pipeline stalls, and Splunk HEC ingestion failures.

## Changes

- **New**: `roles/splunk_docker/templates/savedsearches.conf.j2` — one stanza, deployed to `$SPLUNK_HOME/etc/system/local/savedsearches.conf` (same pattern as `indexes.conf`, `inputs.conf`, etc.)
- **Modified**: `roles/splunk_docker/tasks/main.yml` — adds a `template:` task after `server.conf` deploy, with `notify: Restart Splunk container` to match every other config file
- **New default**: `splunk_docker_alert_email` in `roles/splunk_docker/defaults/main.yml` — empty string by default (email no-ops; alert still surfaces in Splunk UI's Triggered Alerts panel for inventory-less environments)

## Alert design

| Setting | Value | Rationale |
|---|---|---|
| \`cron_schedule\` | \`*/5 * * * *\` | 5-min cadence catches the 15-min threshold within one polling window |
| \`dispatch.earliest_time\` | \`-30m\` | Wider lookback than the threshold so a chain that just recovered doesn't keep firing |
| \`alert.suppress\` | \`60m\` | One alert per outage, not twelve |
| \`relation\` / \`quantity\` | \`greater than 0\` | Fires when the \`where minutes_silent > 15\` filter returns any row |

## Relation to other PRs

- Pack v0.3.0 release: https://github.com/JacobPEvans/cc-edge-the-mac-pack-io/releases/tag/v0.3.0
- Phase D (nix-darwin wire-in): JacobPEvans/nix-darwin#1137
- Phase F (E2E freshness gate): JacobPEvans/ansible-proxmox-apps#273

The Phase F pytest catches the same condition in the scheduled E2E run; this saved search alerts a human between runs. Belt and suspenders.

## Test plan

- [x] \`ansible-lint roles/splunk_docker/\` clean (production profile)
- [x] \`yamllint\` clean
- [ ] Run \`doppler run -- ansible-playbook playbooks/site.yml --tags splunk_docker\` against Splunk VM post-merge
- [ ] Smoke: stop macbook-m4 Cribl Edge daemon ~16 min, confirm alert fires; restart and confirm clear
- [ ] Set inventory \`splunk_docker_alert_email\` so the email action delivers

## Out of scope

- Stream-side filtering for the Mac pack (Edge captures broadly per architectural principle).
- Silence detectors for the other Edge LXCs (Linux 180/181) — separate PR if/when needed.