### PR TITLE
fix(release-please): inherit dryvist/.github org-native caller

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,6 +12,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: JacobPEvans-personal/.github/.github/workflows/_release-please.yml@main
+    uses: dryvist/.github/.github/workflows/_release-please.yml@main
     secrets:
-      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY: ${{ secrets.GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY }}


### PR DESCRIPTION
Flip the release-please caller to `dryvist/.github/_release-please.yml@main`, forwarding `GH_ACTION_RELEASE_PLEASE_PRIVATE_KEY`. Auto-merge + major-bump block come from the reusable workflow once dryvist/.github#22 merges.

Refs: dryvist/.github#22