### PR TITLE
feat(indexes): add llm index + pipeline-silence and manager-panic alerts

### DIFF
--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -90,6 +90,11 @@ splunk_docker_indexes:
   - name: gemini
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"
+  # llm: local LLM-stack telemetry (model-server manager + worker logs,
+  # AI-stack process metrics, AI gateway logs) shipped via Cribl Edge -> Stream.
+  - name: llm
+    max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
+    frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"
   - name: mac_perf
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"

--- a/roles/splunk_docker/templates/savedsearches.conf.j2
+++ b/roles/splunk_docker/templates/savedsearches.conf.j2
@@ -34,3 +34,49 @@ action.email.to = {{ splunk_docker_alert_email }}
 action.email.subject = [Splunk Alert] macOS Cribl Edge chain silent
 action.email.message.alert = The macbook-m4 Cribl Edge pipeline has not delivered any macos:* sourcetype events to Splunk in the last 15+ minutes. Investigate Cribl Edge daemon, Cribl Cloud enrollment, Cribl Stream pipelines, and Splunk HEC ingestion.
 {% endif %}
+
+[llm_pipeline_silence_detector]
+description = Alerts when the llm index (local LLM-stack telemetry via Cribl Edge -> HAProxy -> Cribl Stream) has been silent for more than 30 minutes while expected to flow.
+search = | tstats latest(_time) as last_seen WHERE index=llm | eval minutes_silent = (now() - last_seen) / 60 | where minutes_silent > 30
+dispatch.earliest_time = -24h
+dispatch.latest_time = now
+cron_schedule = */10 * * * *
+enableSched = 1
+is_visible = 1
+disabled = 0
+alert.severity = 3
+alert.suppress = 1
+alert.suppress.period = 120m
+alert.track = 1
+counttype = number of events
+relation = greater than
+quantity = 0
+{% if splunk_docker_alert_email %}
+action.email = 1
+action.email.to = {{ splunk_docker_alert_email }}
+action.email.subject = [Splunk Alert] llm index silent
+action.email.message.alert = The llm index has received no events for 30+ minutes. Investigate the Mac Cribl Edge daemon, HAProxy :10300 frontend, Cribl Stream input, and Splunk HEC ingestion.
+{% endif %}
+
+[llm_manager_panic_detector]
+description = Alerts on model-server manager panics in the llm index (worker lifecycle faults that can leave workers unmanaged).
+search = index=llm sourcetype=llamaswap "panic:"
+dispatch.earliest_time = -15m
+dispatch.latest_time = now
+cron_schedule = */5 * * * *
+enableSched = 1
+is_visible = 1
+disabled = 0
+alert.severity = 4
+alert.suppress = 1
+alert.suppress.period = 60m
+alert.track = 1
+counttype = number of events
+relation = greater than
+quantity = 0
+{% if splunk_docker_alert_email %}
+action.email = 1
+action.email.to = {{ splunk_docker_alert_email }}
+action.email.subject = [Splunk Alert] LLM manager panic detected
+action.email.message.alert = A model-server manager panic reached the llm index. Workers may be unmanaged; check the inference stack and consider a manager restart.
+{% endif %}


### PR DESCRIPTION
## What

- New `llm` index (default sizing/retention) for local LLM-stack telemetry arriving via Cribl Edge → HAProxy → Cribl Stream → HEC.
- Per-index HEC token derives automatically from `HEC_NAMESPACE` (existing `uuidv5` mechanism); the Stream route for this data must use the `llm` token since tokens are index-pinned.
- Two saved-search alerts following the existing silence-detector pattern: `llm_pipeline_silence_detector` (>30 min silent) and `llm_manager_panic_detector` (manager panic signatures).

## How

Index list + alert template render through the existing `indexes.conf.j2` / `savedsearches.conf.j2` paths; no role logic changes.

## Apply

Existing ansible-splunk playbook run.

Refs: dryvist/nix-ai#924

🤖 Generated with [Claude Code](https://claude.com/claude-code)