### PR TITLE
fix(inventory): remove dead cloud.terraform plugin enable; scrub deleted-script references

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -11,4 +11,4 @@ deprecation_warnings = True
 inventory_ignore_extensions = .yml.bak, .yml.orig, .bak, .orig
 
 [inventory]
-enable_plugins = cloud.terraform.terraform_provider, yaml, ini, auto
+enable_plugins = yaml, ini, auto

--- a/playbooks/deploy_docker.yml
+++ b/playbooks/deploy_docker.yml
@@ -4,7 +4,7 @@
 #
 # Prerequisites:
 # - Doppler secrets loaded (SPLUNK_PASSWORD, SPLUNK_HEC_TOKEN)
-# - OpenTofu inventory synced (./scripts/sync-tofu-inventory.sh)
+# - OpenTofu inventory resolvable (S3 read creds, local cache, or TOFU_INVENTORY_PATH)
 #
 # Usage:
 #   doppler run -- uv run ansible-playbook playbooks/deploy_docker.yml

--- a/scripts/test-inventory.sh
+++ b/scripts/test-inventory.sh
@@ -104,7 +104,7 @@ else
 fi
 
 # ============================================================
-# Section 3: Sync script Python parsing
+# Section 3: splunk_vm fixture-shape parsing
 # ============================================================
 echo ""
 echo "=== Sync Script Python Parsing ==="
@@ -130,7 +130,7 @@ cat > "${FIXTURE_JSON}" << 'JSON_EOF'
 }
 JSON_EOF
 
-# Test the same Python logic used in sync-tofu-inventory.sh
+# Parse the splunk_vm entry the way inventory/load_tofu.yml consumes it
 OUTPUT=$(python3 - "${FIXTURE_JSON}" << 'PYEOF'
 import json, sys
 with open(sys.argv[1]) as f:
@@ -148,21 +148,21 @@ PYEOF
 )
 
 if echo "${OUTPUT}" | grep -q "hostname=test-splunk"; then
-  pass "Sync script parses hostname correctly"
+  pass "Fixture parses hostname correctly"
 else
-  fail "Sync script hostname parsing failed"
+  fail "Fixture hostname parsing failed"
 fi
 
 if echo "${OUTPUT}" | grep -q "ip=192.168.0.200"; then
-  pass "Sync script parses IP correctly"
+  pass "Fixture parses IP correctly"
 else
-  fail "Sync script IP parsing failed"
+  fail "Fixture IP parsing failed"
 fi
 
 if echo "${OUTPUT}" | grep -q "vmid=200"; then
-  pass "Sync script parses vmid correctly"
+  pass "Fixture parses vmid correctly"
 else
-  fail "Sync script vmid parsing failed"
+  fail "Fixture vmid parsing failed"
 fi
 
 # ============================================================


### PR DESCRIPTION
Follow-up stragglers from #249 found by a doc sweep:

- `ansible.cfg` still enabled `cloud.terraform.terraform_provider` — the collection was removed in #249 (real bug: broken plugin reference at inventory load).
- `playbooks/deploy_docker.yml` prerequisite comment and `scripts/test-inventory.sh` section labels referenced the deleted `sync-tofu-inventory.sh`; the parsing tests actually validate the splunk_vm fixture shape and are relabeled (still 6/6 passing).

Refs: #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)