### PR TITLE
feat(splunk): netflow index → 90-day retention + 50 GB cap

### DIFF
--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -98,9 +98,11 @@ splunk_docker_indexes:
   - name: mac_perf
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"
+  # netflow: high-volume UniFi IPFIX flow records (split from network) — 90-day
+  # retention + 50 GB cap per terraform-proxmox docs/SPLUNK_INDEXES.md, not the default.
   - name: netflow
-    max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
-    frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"
+    max_size_mb: 51200
+    frozen_time_secs: 7776000
   # netmon: high-volume per-WAN probe telemetry (Telegraf via Cribl) — 90-day
   # retention per terraform-proxmox docs/NETWORK_DIAGNOSIS.md, not the 365-day default.
   - name: netmon


### PR DESCRIPTION
## What
Configures the `netflow` index (UniFi IPFIX flow records, being split out of `network`) as a **high-volume** index: `frozen_time_secs: 7776000` (90 days) + `max_size_mb: 51200` (50 GB), instead of inheriting the 365-day / 100 GB defaults.

## Why
UniFi NetFlow is high-volume; a dedicated index with the netmon-style 90-day / 50 GB envelope isolates that volume without inflating the 365-day `network` index. Matches the spec in `terraform-proxmox` `docs/SPLUNK_INDEXES.md`.

## Note (out of scope here)
The sibling `netmon` entry still uses the default 100 GB `max_size_mb` while its docs document 50 GB — a pre-existing ansible/doc drift, left untouched to keep this PR scoped to netflow.

Refs: dryvist/terraform-proxmox#438 · companion routing change in dryvist/ansible-proxmox-apps.
Deploy = ansible converge; verify `index=netflow` retention via the Splunk MCP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)