### PR TITLE
feat(indexes): add unifi_metrics index (90-day) for UniFi controller telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Cribl Edge (181/182) ──HEC :8088──> Splunk (200)
                                   Splunk indexes:
                                     ai, claude, firewall, gemini,
                                     mac_perf, netflow, netmon, network,
-                                    openai, os, otel, unifi, vscode
+                                    openai, os, otel, unifi, unifi_metrics,
+                                    vscode
 ```
 
 ## Installation
@@ -69,6 +70,7 @@ stored at `/opt/splunk/<index>/`.
 | `os` | Linux / Windows system logs |
 | `otel` | OpenTelemetry spans / metrics |
 | `unifi` | UniFi network syslog |
+| `unifi_metrics` | UniFi controller device/port/client/WAN metrics (unpoller+Telegraf via Cribl, 90-day retention) |
 | `vscode` | VS Code / Copilot events |
 
 ## Technology Add-ons

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -108,6 +108,12 @@ splunk_docker_indexes:
   - name: netmon
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: 7776000
+  # unifi_metrics: UniFi controller telemetry (device cpu/mem/temp, per-port,
+  # per-client, WAN quality) from unpoller+Telegraf via Cribl — 90-day retention,
+  # matching netmon. See ansible-proxmox-apps roles/unifi_metrics.
+  - name: unifi_metrics
+    max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
+    frozen_time_secs: 7776000
   - name: network
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"


### PR DESCRIPTION
## What

Adds the `unifi_metrics` Splunk index (90-day retention, default 100 GiB cap — same profile as `netmon`).

## Why

The companion `ansible-proxmox-apps` PR (`unifi_metrics` role: unpoller + Telegraf) ships **all** UniFi controller telemetry — device cpu/mem/temp, per-port bytes/errors/drops/PoE, per-client signal/rate/satisfaction, WAN quality — via Cribl into Splunk. It needs a home index. (Born from a network investigation where the US-16 switch's sustained ~72% CPU and the gateway's ~80% memory were only visible by live-polling the controller API — this makes them trended and alertable.)

## Note

The `legacy` HEC token's `indexes =` allowlist is generated from `splunk_docker_indexes`, so adding the index here automatically permits Cribl's Splunk-HEC output to write to `unifi_metrics` — no separate token edit.

Render test + ansible-lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)