### PR TITLE
feat(indexes): add unifi_metrics + make unifi_metrics/netmon metric-datatype

### DIFF
--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -123,6 +123,12 @@ splunk_docker_indexes:
   - name: unifi
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"
+  # unifi_metrics: UniFi controller telemetry (unpoller -> Telegraf -> Cribl).
+  # High-volume metric series — 90-day retention per terraform-proxmox docs, not
+  # the 365-day default. Distinguished from netmon by the stream=unifi_metrics tag.
+  - name: unifi_metrics
+    max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
+    frozen_time_secs: 7776000
   - name: vscode
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -105,7 +105,9 @@ splunk_docker_indexes:
     frozen_time_secs: 7776000
   # netmon: high-volume per-WAN probe telemetry (Telegraf via Cribl) — 90-day
   # retention per terraform-proxmox docs/NETWORK_DIAGNOSIS.md, not the 365-day default.
+  # Telegraf ships splunkmetric -> metric index (queryable via mstats), NOT events.
   - name: netmon
+    datatype: metric
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: 7776000
   - name: network
@@ -126,7 +128,9 @@ splunk_docker_indexes:
   # unifi_metrics: UniFi controller telemetry (unpoller -> Telegraf -> Cribl).
   # High-volume metric series — 90-day retention per terraform-proxmox docs, not
   # the 365-day default. Distinguished from netmon by the stream=unifi_metrics tag.
+  # Telegraf ships splunkmetric -> metric index (queryable via mstats), NOT events.
   - name: unifi_metrics
+    datatype: metric
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: 7776000
   - name: vscode

--- a/roles/splunk_docker/templates/indexes.conf.j2
+++ b/roles/splunk_docker/templates/indexes.conf.j2
@@ -8,5 +8,8 @@ coldPath = $SPLUNK_DB/{{ index.name }}/colddb
 thawedPath = $SPLUNK_DB/{{ index.name }}/thaweddb
 maxTotalDataSizeMB = {{ index.max_size_mb }}
 frozenTimePeriodInSecs = {{ index.frozen_time_secs }}
+{% if (index.datatype | default('event')) == 'metric' %}
+datatype = metric
+{% endif %}
 
 {% endfor %}

--- a/tests/templates/test_indexes_conf.py
+++ b/tests/templates/test_indexes_conf.py
@@ -94,6 +94,21 @@ if spurious:
 else:
     print("PASS: empty index list produces no stanzas")
 
+# Test 6: datatype = metric only for indexes flagged datatype: metric
+DATATYPE_INDEXES = [
+    {"name": "events_idx", "max_size_mb": 102400, "frozen_time_secs": 31536000},
+    {"name": "metric_idx", "max_size_mb": 102400, "frozen_time_secs": 7776000, "datatype": "metric"},
+]
+result_dt = template.render(splunk_docker_indexes=DATATYPE_INDEXES)
+metric_stanza = result_dt[result_dt.index("[metric_idx]"):]
+events_stanza = result_dt[result_dt.index("[events_idx]"):result_dt.index("[metric_idx]")]
+if "datatype = metric" not in metric_stanza.split("[metric_idx]")[1].split("\n[")[0]:
+    errors.append("FAIL: metric index missing 'datatype = metric'")
+elif "datatype = metric" in events_stanza:
+    errors.append("FAIL: event index wrongly emitted 'datatype = metric'")
+else:
+    print("PASS: datatype = metric emitted only for metric indexes")
+
 if errors:
     print()
     for err in errors:


### PR DESCRIPTION
## Summary

Adds the `unifi_metrics` index and fixes a datatype bug the live data exposed.

**unifi_metrics + netmon are metric data, not events.** Both are fed by Telegraf with `data_format = splunkmetric` / `splunkmetric_hec_routing`. They were landing in default **event**-type indexes, where each measurement is stored as a broken pseudo-event (`_raw` is literally the word `metric`) — unqueryable via `mstats` and useless for the trended series these exist to provide (device CPU/mem, per-WAN probe latency). Both screenshots from the live system confirmed it.

Changes:
- `indexes.conf.j2`: emit `datatype = metric` for any index flagged `datatype: metric` (defaults to `event`; all other indexes unchanged).
- `splunk_docker_indexes`: add `unifi_metrics`; mark **both** `unifi_metrics` and `netmon` `datatype: metric` (90-day retention).
- `test_indexes_conf.py`: assert `datatype = metric` is emitted only for metric-flagged indexes.

The legacy HEC token's derived allowlist still includes the new index name (per `inputs.conf.j2`), so it remains reachable during the per-index-token migration.

## Operational note

`datatype` is **immutable** on an existing Splunk index. The live event-type `unifi_metrics` and `netmon` indexes must be **deleted and recreated** as metric indexes for this to take effect — their current contents are exactly the broken pseudo-events, so there is no real data loss. Done out-of-band against live Splunk; the role then keeps them correct.

## Verification

`test_indexes_conf.py` passes incl. the new datatype case; rendering the real index list yields `datatype = metric` for exactly `netmon` + `unifi_metrics` and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)