### PR TITLE
fix(hec): make per-index token activation work when HEC_NAMESPACE is set

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -57,7 +57,7 @@
     - name: Validate HEC_NAMESPACE is a valid UUID
       ansible.builtin.assert:
         that:
-          - splunk_docker_hec_namespace | regex_search('^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$', ignorecase=True)
+          - splunk_docker_hec_namespace is match('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
         fail_msg: >-
           HEC_NAMESPACE must be a valid UUID (e.g. uuidgen output).
           Got: {{ splunk_docker_hec_namespace | default('(empty)') }}

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -36,6 +36,12 @@
   become: true
   gather_facts: true
 
+  # Load the role's index list up front so the per-index HEC token derivation
+  # below can reference splunk_docker_indexes before the role is included
+  # (mirrors playbooks/validate.yml).
+  vars_files:
+    - ../roles/splunk_docker/defaults/main.yml
+
   tasks:
     - name: Validate required environment variables
       ansible.builtin.assert:


### PR DESCRIPTION
Two latent bugs that only surface the first time `HEC_NAMESPACE` is set (i.e. when per-index HEC tokens are actually activated — it had never been set before):

1. **UUID assert was non-boolean.** `Validate HEC_NAMESPACE is a valid UUID` used `regex_search()`, which returns the matched string. ansible-core 2.19+ rejects non-boolean conditionals (`Conditionals must have a boolean result`). Switched to the `is match` test.

2. **Index list out of scope during derivation.** `Derive per-index HEC token values` references `splunk_docker_indexes` (a `splunk_docker` role default) in the Deploy Splunk play's tasks, which run *before* the role is included → undefined var → task failure. Added `vars_files` for the role defaults to the play (mirrors `validate.yml`).

## Verified live

Converge with `HEC_NAMESPACE` set mints `http://<index>` per-index HEC tokens (`token = uuid5('splunk-hec-<index>', HEC_NAMESPACE)`); `http://unifi_metrics` accepts `index=unifi_metrics`; `http://legacy` stays `= SPLUNK_HEC_TOKEN` and still works — no existing sender broken.

🤖 Generated with [Claude Code](https://claude.com/claude-code)