### PR TITLE
fix(deps): widen community.general ceiling to major (<14.0.0)

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,7 +3,7 @@ collections:
   - name: ansible.posix
     version: ">=2.1.0,<3.0.0"
   - name: community.general
-    version: ">=13.0.0,<13.1.0"
+    version: ">=13.0.0,<14.0.0"
   - name: community.docker
     version: ">=5.0.6,<6.0.0"
   # S3 inventory resolver (inventory/load_tofu.yml): aws_caller_info + s3_object


### PR DESCRIPTION
## Problem

`community.general` was capped `>=13.0.0,<13.1.0` (patch-only), blocking **13.1.0** (current latest on Galaxy). The ceiling predates 13.1.0's release (set 2026-01-20, carried through Renovate #210) and has no incompatibility rationale.

It's also inconsistent with every other collection in `requirements.yml`, which use **major** ceilings:
- `ansible.posix >=2.1.0,<3.0.0`
- `community.docker >=5.0.6,<6.0.0`

## Fix

Align to `>=13.0.0,<14.0.0` so the resolver tracks all of 13.x (= 13.1.0 today) and Renovate can propose 14.0.0 as a reviewed major. Molecule CI validates the bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)