### PR TITLE
feat(inventory): make S3 the sole live inventory source; remove local-cache staleness hole

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,28 @@ for ancillary services — those belong in `ansible-proxmox-apps` as LXC.
   `inventory/load_tofu.yml` resolves it: `TOFU_INVENTORY_PATH` (explicit
   pin) → S3 artifact (native `amazon.aws`, AWS read creds only — no
   checkout, no toolchain; overrides: `TOFU_INVENTORY_S3_URI`,
-  `TOFU_INVENTORY_S3_REGION`) → local gitignored cache → static fallback
-  (`SPLUNK_VM_HOST`, else DNS-first `splunk-aio.{PROXMOX_DOMAIN}`).
+  `TOFU_INVENTORY_S3_REGION`) → static fallback (`SPLUNK_VM_HOST`, else
+  DNS-first `splunk-aio.{PROXMOX_DOMAIN}`). There is **no local-cache step**
+  — see "Inventory freshness guarantee" below.
+
+#### Inventory freshness guarantee (single-writer / readers-always-latest)
+
+S3 is the single source of truth; this repo is a **read-only consumer** and
+holds no authoritative local inventory.
+
+- **Single writer**: `terraform-proxmox` serializes every `apply` with a dual
+  state lock (`use_lockfile` S3-native **and** the
+  `terraform-proxmox-locks-useast2` DynamoDB table), then republishes the
+  artifact with a single atomic `aws_s3_object` PUT. Two applies cannot both
+  publish. This lock lives in the producer — a consumer repo cannot (and must
+  not) reimplement it.
+- **Readers always get the latest**: S3 strong read-after-write consistency —
+  every GET returns the most recent PUT; concurrent reads need no lock. The S3
+  fetch retries transient blips before degrading.
+- **No staleness hole**: there is deliberately no on-disk inventory cache. The
+  only non-S3 source is the DNS-first static fallback, and that A-record is
+  itself continuously reconciled from this same inventory (Technitium) — a live
+  source for the Splunk VM address, not a frozen copy.
 
 ### External services
 

--- a/inventory/.gitignore
+++ b/inventory/.gitignore
@@ -1,2 +1,5 @@
-# OpenTofu-generated inventory (contains IPs and infrastructure details)
-tofu_inventory.json
+# OpenTofu-generated inventory caches (IPs/infra details) — never commit.
+# Glob catches any name (tofu_*, legacy terraform_*) so a stale cache can't
+# reappear untracked; the schema example is kept.
+*_inventory.json
+!*_inventory.json.example

--- a/inventory/load_tofu.yml
+++ b/inventory/load_tofu.yml
@@ -8,19 +8,20 @@
   gather_facts: false
   become: false
 
-  # Inventory source resolution (priority order, first that resolves wins):
-  #   1. TOFU_INVENTORY_PATH  — explicit local path / pin (tests, overrides)
+  # Inventory source resolution (priority order, first that resolves wins).
+  # S3 is the single source of truth; there is deliberately NO local-cache step,
+  # so no on-disk inventory file can ever go stale and be read (see AGENTS.md
+  # "Inventory freshness guarantee").
+  #   1. TOFU_INVENTORY_PATH  — explicit local path / pin (tests, DR overrides)
   #   2. S3 published artifact — `terragrunt apply` publishes the RAW tofu output
   #      to the terraform-proxmox state bucket; fetched natively (amazon.aws,
   #      boto3 from the dev shell — no aws CLI, no checkout, no toolchain).
   #      Location override: TOFU_INVENTORY_S3_URI, else derived from the account.
-  #   3. inventory/tofu_inventory.json — the local gitignored cache the
-  #      terraform-proxmox after-hook writes.
-  #   4. No tofu data at all — the static hosts.yml entry still works via
-  #      SPLUNK_VM_HOST, or DNS-first via splunk-aio.{PROXMOX_DOMAIN}.
+  #   3. No tofu data at all — the static hosts.yml entry still works via
+  #      SPLUNK_VM_HOST, or DNS-first via splunk-aio.{PROXMOX_DOMAIN} (a
+  #      self-hosted A-record continuously reconciled from this same inventory).
   vars:
     tofu_inventory_path: "{{ lookup('env', 'TOFU_INVENTORY_PATH') | default('', true) }}"
-    tofu_inventory_local: "{{ playbook_dir }}/../inventory/tofu_inventory.json"
     tofu_inventory_s3_uri: "{{ lookup('env', 'TOFU_INVENTORY_S3_URI') | default('', true) }}"
     tofu_inventory_s3_region: "{{ lookup('env', 'TOFU_INVENTORY_S3_REGION') | default('us-east-2', true) }}"
 
@@ -39,8 +40,8 @@
         - tofu_inv_explicit.stat.exists | default(false)
 
     # Native amazon.aws modules (boto3 from the dev shell). Both lookups are
-    # best-effort: on missing creds/boto3 the chain falls through to the local
-    # cache, mirroring the explicit-path step.
+    # best-effort: on missing creds/boto3 the chain falls through to the
+    # DNS-first static fallback, mirroring the explicit-path step.
     - name: Resolve the published S3 inventory
       when: tofu_inventory_resolved is not defined
       block:
@@ -65,8 +66,8 @@
 
         # Inventory resolution is read-only and must work under --check too
         # (tempfile creates no path in check mode, which would blow up the
-        # download's dest templating before failed_when applies) — so the
-        # fetch pair always really runs (check_mode: false).
+        # download's dest templating) — so the fetch pair always really runs
+        # (check_mode: false).
         - name: Fetch the published inventory from S3
           when: tofu_inventory_s3_effective | length > 0
           block:
@@ -77,21 +78,38 @@
               register: tofu_inv_tmp
               check_mode: false
 
-            - name: Download the inventory from S3
-              amazon.aws.s3_object:
-                bucket: "{{ tofu_inventory_s3_effective | regex_replace('^s3://([^/]+)/.*$', '\\1') }}"
-                object: "{{ tofu_inventory_s3_effective | regex_replace('^s3://[^/]+/', '') }}"
-                dest: "{{ tofu_inv_tmp.path }}"
-                mode: get
-                region: "{{ tofu_inventory_s3_region }}"
-              register: tofu_inv_s3
-              changed_when: false
-              failed_when: false
-              check_mode: false
+            # Retry transient S3 blips (throttle/network) before degrading to
+            # DNS — the DNS fallback carries only the Splunk address, so a retry
+            # keeps the full-data path (tofu_data.constants.*) when the blip is
+            # momentary. No-creds is NOT retried here: this block only runs with
+            # an effective URI, which requires creds to have resolved upstream.
+            - name: Download the inventory from S3 (retry transient failures)
+              block:
+                - name: Get the published S3 inventory object
+                  amazon.aws.s3_object:
+                    bucket: "{{ tofu_inventory_s3_effective | regex_replace('^s3://([^/]+)/.*$', '\\1') }}"
+                    object: "{{ tofu_inventory_s3_effective | regex_replace('^s3://[^/]+/', '') }}"
+                    dest: "{{ tofu_inv_tmp.path }}"
+                    mode: get
+                    region: "{{ tofu_inventory_s3_region }}"
+                  register: tofu_inv_s3
+                  changed_when: false
+                  retries: 2
+                  delay: 3
+                  until: tofu_inv_s3 is succeeded
+                  check_mode: false
+              rescue:
+                # Reached only after retries are exhausted. Swallow it: the temp
+                # file stays empty, fails the size check below, and the chain
+                # falls through to the DNS-first static fallback.
+                - name: Note the S3 inventory fetch failed; fall through to DNS
+                  ansible.builtin.debug:
+                    msg: >-
+                      S3 inventory fetch failed after retries; falling through to
+                      the DNS-first static fallback.
 
-            # failed_when:false masks the module's failed flag, so success is
-            # judged by the artifact itself: the GET overwrote the empty temp
-            # file with content.
+            # Success is judged by the artifact itself: a successful GET
+            # overwrote the empty temp file with content.
             - name: Stat the downloaded inventory
               ansible.builtin.stat:
                 path: "{{ tofu_inv_tmp.path }}"
@@ -102,19 +120,6 @@
                 tofu_inventory_resolved: "{{ tofu_inv_tmp.path }}"
               when: (tofu_inv_s3_stat.stat.size | default(0)) > 0
 
-    - name: Stat the local inventory cache
-      ansible.builtin.stat:
-        path: "{{ tofu_inventory_local }}"
-      register: tofu_inv_localstat
-      when: tofu_inventory_resolved is not defined
-
-    - name: Resolve inventory from the local cache when present
-      ansible.builtin.set_fact:
-        tofu_inventory_resolved: "{{ tofu_inventory_local }}"
-      when:
-        - tofu_inventory_resolved is not defined
-        - tofu_inv_localstat.stat.exists | default(false)
-
     # Static fallback (hosts.yml splunk-01) needs SPLUNK_VM_HOST or, DNS-first,
     # PROXMOX_DOMAIN (splunk-aio.{domain} — Technitium serves the VM hostname
     # A-record derived from the same inventory).
@@ -124,13 +129,12 @@
           OpenTofu inventory could not be resolved from any source:
             1. TOFU_INVENTORY_PATH : {{ tofu_inventory_path | default('(unset)', true) }}
             2. S3 artifact         : {{ tofu_inventory_s3_effective | default('(no AWS creds / URI)', true) }}
-            3. local cache         : {{ tofu_inventory_local }}
 
           Provide ONE of:
             - Read creds for the S3 artifact (CI: OIDC role; agents: scoped role);
               optionally set TOFU_INVENTORY_S3_URI to override the location.
-            - TOFU_INVENTORY_PATH pointing at a local copy.
-            - Run terraform-proxmox apply so the after-hook publishes + syncs.
+            - TOFU_INVENTORY_PATH pointing at a local copy (tests / DR override).
+            - Run terraform-proxmox apply so the S3 artifact is republished.
             - Static fallback: SPLUNK_VM_HOST, or PROXMOX_DOMAIN for the
               DNS-first default (splunk-aio.{domain}).
       when:


### PR DESCRIPTION
## Why

`inventory/terraform_inventory.json` kept showing up untracked. Investigating the AWS migration (#241 rename, #249 S3-first) showed the migration is **done** — but two holes still let a session read **stale on-disk inventory** instead of the latest S3 artifact:

1. `terraform_inventory.json` — pre-rename leftover, never re-gitignored (only `tofu_inventory.json` was). Dead: nothing references it.
2. The local-cache read step in `load_tofu.yml` — a no-creds session with a stale cache on disk reads stale data.

## What

- **`load_tofu.yml`**: drop the local-cache read step + `tofu_inventory_local` var. Resolution is now `TOFU_INVENTORY_PATH` → **S3** → DNS-first static fallback. No on-disk inventory cache is ever read → staleness is structurally impossible.
- **S3 retry**: bounded `retries: 2 / delay: 3` via `block`/`rescue` so a transient blip keeps the full-data path (`tofu_data.constants.*`) before degrading to the address-only DNS fallback; a final failure still falls through, never aborts. (No-creds is filtered upstream, so it isn't retried.)
- **`.gitignore`**: glob `*_inventory.json` (+ keep `.example`) so any cache name — new `tofu_*` or legacy `terraform_*` — can never reappear untracked.
- **`AGENTS.md`**: document the verified guarantee.

## The single-writer / readers-always-latest guarantee (verified, not reimplemented)

This repo is a **read-only consumer**; the guarantee is inherent to the producer's S3 design, verified in `dryvist/terraform-proxmox`:

- **Single writer** — `terragrunt.hcl` dual lock: `use_lockfile` (S3-native) **and** the `terraform-proxmox-locks-useast2` DynamoDB table. Two applies can't both publish.
- **Atomic publish** — `inventory_publish.tf` `aws_s3_object` single content-PUT (atomic overwrite).
- **Readers latest** — S3 strong read-after-write consistency; concurrent reads need no lock.

## Design notes

Consulted Codex + Grok-4.20. Both confirmed: delete the file cache, keep the S3 artifact contract, don't switch to direct remote-state (`cloud.terraform.terraform_state` reads raw state *resources*, not derived outputs), don't add Consul/etcd. **Kept** the DNS fallback (Codex wanted fail-closed) — the Technitium A-record is self-hosted, always-on, and continuously reconciled from this same inventory, so it's a live source for the one fact this repo needs, not a stale copy.

## Out of scope (follow-ups)

- Native-Ansible-inventory conversion of the S3 object (ripples across terraform-proxmox + all 3 consumers).
- Siblings `ansible-proxmox` / `ansible-proxmox-apps` carry the same cache read path — separate PRs.
- The `infra-orchestration:sync-inventory` skill still documents the old copy-into-each-repo model.

## Verification

- `ansible-lint` (production) clean; `--syntax-check` clean.
- Fixture run (`TOFU_INVENTORY_PATH=…/tofu_inventory.json.example`) → Splunk VM added, `failed=0`.
- No-creds run (`PROXMOX_DOMAIN` set, S3 unreachable) → DNS fallback, `failed=0`, no abort.
- `git check-ignore`: both cache names ignored, `.example` kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)