### PR TITLE
fix(splunk): rename metric index netmon -> netmon_metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Cribl Edge (181/182) ──HEC :8088──> Splunk (200)
                                       │
                                   Splunk indexes:
                                     ai, claude, firewall, gemini,
-                                    mac_perf, netflow, netmon, network,
+                                    mac_perf, netflow, netmon_metrics, network,
                                     openai, os, otel, unifi, unifi_metrics,
                                     vscode
 ```
@@ -53,7 +53,7 @@ doppler run -- ansible-playbook playbooks/validate.yml
 
 ## Custom Indexes
 
-All indexes: 100 GiB max size, 365-day retention (except `netmon`: 90-day),
+All indexes: 100 GiB max size, 365-day retention (except `netmon_metrics`: 90-day),
 stored at `/opt/splunk/<index>/`.
 
 | Index | Purpose |
@@ -64,7 +64,7 @@ stored at `/opt/splunk/<index>/`.
 | `gemini` | Gemini-specific events |
 | `mac_perf` | macOS performance metrics |
 | `netflow` | NetFlow / IPFIX flow data |
-| `netmon` | Per-WAN network-diagnosis probe telemetry (90-day retention) |
+| `netmon_metrics` | Per-WAN network-diagnosis probe telemetry, metric index (90-day retention) |
 | `network` | Network device syslog |
 | `openai` | OpenAI-specific events |
 | `os` | Linux / Windows system logs |

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -20,7 +20,7 @@
       gemini: "molecule-test-token-gemini"
       mac_perf: "molecule-test-token-mac-perf"
       netflow: "molecule-test-token-netflow"
-      netmon: "molecule-test-token-netmon"
+      netmon_metrics: "molecule-test-token-netmon-metrics"
       network: "molecule-test-token-network"
       openai: "molecule-test-token-openai"
       otel: "molecule-test-token-otel"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -104,7 +104,7 @@
         that:
           - "'[unifi]' in (indexes_content.content | b64decode)"
           - "'[netflow]' in (indexes_content.content | b64decode)"
-          - "'[netmon]' in (indexes_content.content | b64decode)"
+          - "'[netmon_metrics]' in (indexes_content.content | b64decode)"
           - "'[firewall]' in (indexes_content.content | b64decode)"
           - "'[network]' in (indexes_content.content | b64decode)"
           - "'[os]' in (indexes_content.content | b64decode)"

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -106,10 +106,11 @@ splunk_docker_indexes:
   - name: netflow
     max_size_mb: 51200
     frozen_time_secs: 7776000
-  # netmon: high-volume per-WAN probe telemetry (Telegraf via Cribl) — 90-day
+  # netmon_metrics: high-volume per-WAN probe telemetry (Telegraf via Cribl) — 90-day
   # retention per terraform-proxmox docs/NETWORK_DIAGNOSIS.md, not the 365-day default.
   # Telegraf ships splunkmetric -> metric index (queryable via mstats), NOT events.
-  - name: netmon
+  # Metric indexes carry the _metrics suffix by convention.
+  - name: netmon_metrics
     datatype: metric
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: 7776000


### PR DESCRIPTION
## Why

Splunk logged a recurring `IndexProcessor` WARN: a metric `value=null` reaching the `netmon` metric index. Investigation also surfaced that `netmon` is a metric-datatype index that violates the `{name}_metrics` naming convention (`unifi_metrics` already complies).

This PR is the **index-definition** half. The null-value coercion + Cribl repoint is in `dryvist/ansible-proxmox-apps`.

## What

- Rename the metric index `netmon` → `netmon_metrics` (keeps `datatype: metric`, 90-day retention).
- Update molecule `converge.yml` (HEC token key) and `verify.yml` (`[netmon_metrics]` stanza assert).
- Update README index list/table.

## Deploy note

A metric index cannot be renamed in place. Converge **creates** `netmon_metrics`; the old `netmon` keeps its ≤90-day data until it freezes, then can be removed. Apply this **before** the ansible-proxmox-apps Cribl repoint so the new index exists when Cribl starts stamping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)