### PR TITLE
feat(splunk): always-latest Splunkbase apps, in-flow + air-gapped; fix install-once

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -6,6 +6,15 @@
 - name: Load OpenTofu inventory
   ansible.builtin.import_playbook: ../inventory/load_tofu.yml
 
+# Resolve the latest Splunkbase app versions and mirror them into MinIO BEFORE
+# deploying, so every run installs current apps. Runs entirely on the controller
+# (which has internet egress); the Splunk VM stays air-gapped and only pulls from
+# MinIO. Fail-soft: a Splunkbase outage is rescued inside this playbook and the
+# deploy proceeds from whatever MinIO already holds. Requires the Splunkbase +
+# MinIO secrets in the environment (provided by `doppler run --`).
+- name: Sync latest Splunkbase apps into MinIO (in-flow, fail-soft)
+  ansible.builtin.import_playbook: sync-splunkbase.yml
+
 # Configure NTP time synchronization BEFORE deploying Splunk. Splunk's
 # _time correlation depends on accurate clocks; points at the Proxmox
 # hosts (stratum-2 servers managed by ansible-proxmox) when Doppler

--- a/playbooks/sync-splunkbase.yml
+++ b/playbooks/sync-splunkbase.yml
@@ -1,39 +1,43 @@
 ---
-# Splunkbase → MinIO sync playbook
+# Splunkbase → MinIO sync playbook (resolves LATEST, mirrors, writes manifest)
 #
-# Authenticates to Splunkbase, downloads every entry in addons.yml that has
-# a `splunkbase_id` + `version`, and mirrors it into the `splunk-addons`
-# MinIO bucket with `version=X.Y.Z&splunkbase_id=NNNN` tags.
+# For every addons.yml entry with a `splunkbase_id`, resolves the latest release
+# from the PUBLIC Splunkbase API (no auth needed for resolution), downloads it with
+# the authenticated session, and mirrors it into the `splunk-addons` MinIO bucket
+# tagged `version=X.Y.Z&splunkbase_id=NNNN`. Finally writes `manifest.json`
+# (app_dir → {version, filename}) to the bucket — the version bridge the air-gapped
+# Splunk VM reads over the LAN to know which apps to (re)extract.
 #
-# Idempotent: queries the current `version` tag on each MinIO object and
-# skips entries whose tag already matches the pinned registry version.
-# To rotate an app, bump the `version` field in addons.yml and re-run.
+# `pin_version` on an entry overrides resolution (hold back a bad release).
+#
+# Idempotent: skips download when the MinIO `version` tag already matches the
+# resolved latest. Fail-soft: if Splunkbase is unreachable, the whole resolve/sync
+# block is rescued — the existing MinIO contents + manifest are left intact so a
+# deploy can still proceed. This playbook also runs as an in-flow pre-play of
+# site.yml; it stays usable standalone for manual/scheduled syncs.
 #
 # Credentials (Doppler):
-#   SPLUNKBASE_USERNAME / SPLUNKBASE_PASSWORD — Splunkbase account
+#   SPLUNKBASE_USERNAME / SPLUNKBASE_PASSWORD — Splunkbase account (download only)
 #   MINIO_ROOT_USER     / MINIO_ROOT_PASSWORD — MinIO bucket write auth
 #
 # Usage:
 #   doppler run -- ansible-playbook playbooks/sync-splunkbase.yml
 #
-# Runs entirely on localhost (the Ansible controller). No target host
-# operations — MinIO is the sink, Splunkbase is the source.
+# Runs entirely on localhost (the Ansible controller, which has internet egress).
+# The Splunk VM never contacts Splunkbase — air-gap preserved.
 
 - name: Load OpenTofu inventory (for MinIO endpoint)
   ansible.builtin.import_playbook: ../inventory/load_tofu.yml
 
-- name: Mirror Splunkbase add-ons into MinIO
+- name: Mirror latest Splunkbase add-ons into MinIO
   hosts: localhost
   connection: local
   gather_facts: false
   vars:
+    splunkbase_api: "{{ splunkbase_api_url | default('https://splunkbase.splunk.com') }}"
     splunkbase_sync_tmpdir: /tmp/splunkbase-sync
-    minio_endpoint: >-
-      http://{{ hostvars['localhost']['tofu_data']['containers']['minio']['ip'] }}:{{
-      hostvars['localhost']['tofu_data']['constants']['service_ports']['minio_api'] }}
     minio_bucket: splunk-addons
-    # mc uses this env var to resolve the `homelab` alias without touching
-    # any persisted alias file — keeps the playbook stateless.
+    # mc resolves the `homelab` alias from this env var — no persisted alias file.
     mc_env:
       MC_HOST_homelab: >-
         http://{{ lookup('env', 'MINIO_ROOT_USER') }}:{{
@@ -64,11 +68,9 @@
           - item.filename is defined
           - item.app_dir is defined
           - not (item.splunkbase_id is defined and item.github_repo is defined)
-          - not (item.splunkbase_id is defined) or item.version is defined
         fail_msg: >-
-          Invalid registry entry {{ item }}: each entry must have filename + app_dir,
-          may have at most one of (splunkbase_id, github_repo), and splunkbase_id
-          requires a paired `version`.
+          Invalid registry entry {{ item }}: each entry must have filename + app_dir
+          and may have at most one of (splunkbase_id, github_repo).
       loop: "{{ splunk_docker_addons }}"
       loop_control:
         label: "{{ item.filename | default('(no filename)') }}"
@@ -76,10 +78,7 @@
     - name: Build list of Splunkbase-syncable entries
       ansible.builtin.set_fact:
         splunkbase_entries: >-
-          {{ splunk_docker_addons
-             | selectattr('splunkbase_id', 'defined')
-             | selectattr('version', 'defined')
-             | list }}
+          {{ splunk_docker_addons | selectattr('splunkbase_id', 'defined') | list }}
 
     - name: Ensure temporary download directory exists
       ansible.builtin.file:
@@ -87,156 +86,241 @@
         state: directory
         mode: "0700"
 
-    # `mc tag list --json` returns nonzero in two distinct cases. The
-    # validation task below distinguishes them so the playbook fails loud
-    # for everything except "object missing":
-    #   1. Object missing — expected, drives a sync. mc emits
-    #      "Code":"NoSuchKey" in the stdout JSON.
-    #   2. Anything else — auth failure, network down, mc not installed,
-    #      bucket missing — must fail loud, NOT silently re-download every
-    #      archive into a bucket we may not have write access to.
-    # `failed_when` can't reference `rc` directly inside a loop, so we
-    # collect raw results here and validate them in the next task.
-    - name: Query current MinIO version tag for each entry
-      ansible.builtin.command:
-        cmd: "mc tag list --json homelab/{{ minio_bucket }}/{{ item.filename }}"
-      environment: "{{ mc_env }}"
-      loop: "{{ splunkbase_entries }}"
-      loop_control:
-        label: "{{ item.filename }}"
-      register: minio_tag_query
-      changed_when: false
-      failed_when: false
-      no_log: true
+    # Resolve → download → mirror → manifest. Wrapped in block/rescue so a
+    # Splunkbase outage degrades gracefully: the deploy continues from whatever
+    # MinIO already holds (the existing manifest is left untouched).
+    - name: Resolve latest, sync drifted apps, and publish manifest
+      block:
+        # PUBLIC endpoint — no auth. Newest release is element [0].
+        - name: Resolve latest release per Splunkbase entry
+          ansible.builtin.uri:
+            url: "{{ splunkbase_api }}/api/v1/app/{{ item.splunkbase_id }}/release/"
+            method: GET
+            return_content: true
+            status_code: 200
+            timeout: 30
+          register: splunkbase_release_q
+          loop: "{{ splunkbase_entries }}"
+          loop_control:
+            label: "app {{ item.splunkbase_id }}"
+          changed_when: false
+          failed_when: false
 
-    - name: Validate query errors are only missing-object cases
-      ansible.builtin.assert:
-        that:
-          - item.rc == 0 or 'NoSuchKey' in (item.stdout | default(''))
-        fail_msg: >-
-          mc tag list failed for {{ item.item.filename }} with rc={{ item.rc }}.
-          This is not a "missing object" — check MinIO connectivity,
-          MINIO_ROOT_USER/PASSWORD, and bucket existence.
-        quiet: true
-      loop: "{{ minio_tag_query.results }}"
-      loop_control:
-        label: "{{ item.item.filename }}"
+        - name: Compute desired version per entry (pin_version overrides latest)
+          ansible.builtin.set_fact:
+            splunkbase_desired: >-
+              {{ splunkbase_desired | default([]) + [item.0 | combine({
+                'desired_version': (
+                  item.0.pin_version if item.0.pin_version is defined
+                  else (
+                    (item.1.content | from_json | first).name
+                    if (item.1.status | default(0)) == 200 and (item.1.content | default('')) | length > 0
+                    else ''
+                  )
+                )
+              })] }}
+          loop: "{{ splunkbase_entries | zip(splunkbase_release_q.results) | list }}"
+          loop_control:
+            label: "{{ item.0.filename }}"
 
-    - name: Compute sync decisions (which entries need (re)download)
-      ansible.builtin.set_fact:
-        splunkbase_plan: >-
-          {{ splunkbase_plan | default([]) + [item.item | combine({
-            'current_version': (
-              (item.stdout | default('{}') | from_json).tagset.version
-              | default('') | trim
-            ) if item.rc == 0 else '',
-            'needs_sync': (
-              item.rc != 0
-              or ((item.stdout | default('{}') | from_json).tagset.version
-                  | default('') | trim) != (item.item.version | string | trim)
-            ),
-          })] }}
-      loop: "{{ minio_tag_query.results }}"
-      loop_control:
-        label: "{{ item.item.filename }}"
+        - name: Warn about entries whose latest version could not be resolved
+          ansible.builtin.debug:
+            msg: >-
+              Could not resolve a version for {{ item.filename }}
+              (splunkbase_id {{ item.splunkbase_id }}); skipping it this run.
+          loop: "{{ splunkbase_desired | selectattr('desired_version', 'equalto', '') | list }}"
+          loop_control:
+            label: "{{ item.filename }}"
 
-    - name: Show sync decisions
-      ansible.builtin.debug:
-        msg: >-
-          {{ item.filename }}: registry={{ item.version }}
-          minio={{ item.current_version or '(none)' }}
-          → {{ 'SYNC' if item.needs_sync else 'skip' }}
-      loop: "{{ splunkbase_plan }}"
-      loop_control:
-        label: "{{ item.filename }}"
+        - name: Keep only resolvable entries
+          ansible.builtin.set_fact:
+            splunkbase_desired: >-
+              {{ splunkbase_desired | rejectattr('desired_version', 'equalto', '') | list }}
 
-    - name: Build list of entries that need sync
-      ansible.builtin.set_fact:
-        splunkbase_to_sync: "{{ splunkbase_plan | selectattr('needs_sync') | list }}"
+        # `mc tag list --json` returns nonzero for a missing object ("NoSuchKey"
+        # in stdout) — expected, drives a sync. Any other nonzero (auth/network/
+        # bucket) must fail loud, validated in the next task.
+        - name: Query current MinIO version tag for each entry
+          ansible.builtin.command:
+            cmd: "mc tag list --json homelab/{{ minio_bucket }}/{{ item.filename }}"
+          environment: "{{ mc_env }}"
+          loop: "{{ splunkbase_desired }}"
+          loop_control:
+            label: "{{ item.filename }}"
+          register: minio_tag_query
+          changed_when: false
+          failed_when: false
+          no_log: true
 
-    - name: Skip remaining tasks when everything is already in sync
-      ansible.builtin.meta: end_play
-      when: splunkbase_to_sync | length == 0
+        - name: Validate query errors are only missing-object cases
+          ansible.builtin.assert:
+            that:
+              - item.rc == 0 or 'NoSuchKey' in (item.stdout | default(''))
+            fail_msg: >-
+              mc tag list failed for {{ item.item.filename }} with rc={{ item.rc }}.
+              Not a "missing object" — check MinIO connectivity,
+              MINIO_ROOT_USER/PASSWORD, and bucket existence.
+            quiet: true
+          loop: "{{ minio_tag_query.results }}"
+          loop_control:
+            label: "{{ item.item.filename }}"
 
-    - name: Authenticate to Splunkbase
-      ansible.builtin.uri:
-        url: "{{ splunkbase_api_url | default('https://splunkbase.splunk.com') }}/api/account:login/"
-        method: POST
-        body_format: form-urlencoded
-        body:
-          username: "{{ lookup('env', 'SPLUNKBASE_USERNAME') }}"
-          password: "{{ lookup('env', 'SPLUNKBASE_PASSWORD') }}"
-        return_content: true
-        status_code: 200
-      register: splunkbase_login
-      no_log: true
+        - name: Compute sync decisions (MinIO tag vs resolved latest)
+          ansible.builtin.set_fact:
+            splunkbase_plan: >-
+              {{ splunkbase_plan | default([]) + [item.item | combine({
+                'current_version': (
+                  (item.stdout | default('{}') | from_json).tagset.version
+                  | default('') | trim
+                ) if item.rc == 0 else '',
+                'needs_sync': (
+                  item.rc != 0
+                  or ((item.stdout | default('{}') | from_json).tagset.version
+                      | default('') | trim) != (item.item.desired_version | string | trim)
+                ),
+              })] }}
+          loop: "{{ minio_tag_query.results }}"
+          loop_control:
+            label: "{{ item.item.filename }}"
 
-    - name: Extract Splunkbase session token
-      ansible.builtin.set_fact:
-        splunkbase_token: >-
-          {{ splunkbase_login.content
-             | regex_search('<id>([^<]+)</id>', '\1')
-             | first }}
-      no_log: true
+        - name: Show sync decisions
+          ansible.builtin.debug:
+            msg: >-
+              {{ item.filename }}: latest={{ item.desired_version }}
+              minio={{ item.current_version or '(none)' }}
+              → {{ 'SYNC' if item.needs_sync else 'skip' }}
+          loop: "{{ splunkbase_plan }}"
+          loop_control:
+            label: "{{ item.filename }}"
 
-    - name: Fail if session token not returned
-      ansible.builtin.assert:
-        that:
-          - splunkbase_token is defined
-          - splunkbase_token | length > 0
-        fail_msg: >-
-          Splunkbase login returned no session token. Check
-          SPLUNKBASE_USERNAME / SPLUNKBASE_PASSWORD in Doppler.
+        - name: Build list of entries that need sync
+          ansible.builtin.set_fact:
+            splunkbase_to_sync: "{{ splunkbase_plan | selectattr('needs_sync') | list }}"
 
-    - name: Download drifted entries from Splunkbase
-      ansible.builtin.get_url:
-        url: >-
-          {{ splunkbase_api_url | default('https://splunkbase.splunk.com') }}/app/{{ item.splunkbase_id }}/release/{{ item.version }}/download/
-        dest: "{{ splunkbase_sync_tmpdir }}/{{ item.filename }}"
-        headers:
-          X-Auth-Token: "{{ splunkbase_token }}"
-        force: true
-        mode: "0600"
-        timeout: 120
-      loop: "{{ splunkbase_to_sync }}"
-      loop_control:
-        label: "{{ item.filename }} v{{ item.version }}"
+        - name: Authenticate to Splunkbase (only when something needs downloading)
+          ansible.builtin.uri:
+            url: "{{ splunkbase_api }}/api/account:login/"
+            method: POST
+            body_format: form-urlencoded
+            body:
+              username: "{{ lookup('env', 'SPLUNKBASE_USERNAME') }}"
+              password: "{{ lookup('env', 'SPLUNKBASE_PASSWORD') }}"
+            return_content: true
+            status_code: 200
+          register: splunkbase_login
+          when: splunkbase_to_sync | length > 0
+          no_log: true
 
-    - name: Upload synced archives to MinIO
-      ansible.builtin.command:
-        cmd: >-
-          mc cp
-          {{ splunkbase_sync_tmpdir }}/{{ item.filename }}
-          homelab/{{ minio_bucket }}/{{ item.filename }}
-      environment: "{{ mc_env }}"
-      loop: "{{ splunkbase_to_sync }}"
-      loop_control:
-        label: "{{ item.filename }}"
-      changed_when: true
+        - name: Extract Splunkbase session token
+          ansible.builtin.set_fact:
+            splunkbase_token: >-
+              {{ splunkbase_login.content
+                 | regex_search('<id>([^<]+)</id>', '\1')
+                 | first }}
+          when: splunkbase_to_sync | length > 0
+          no_log: true
 
-    - name: Tag MinIO objects with version + splunkbase_id
-      ansible.builtin.command:
-        cmd: >-
-          mc tag set
-          homelab/{{ minio_bucket }}/{{ item.filename }}
-          version={{ item.version }}&splunkbase_id={{ item.splunkbase_id }}
-      environment: "{{ mc_env }}"
-      loop: "{{ splunkbase_to_sync }}"
-      loop_control:
-        label: "{{ item.filename }}"
-      changed_when: true
+        - name: Fail if session token not returned
+          ansible.builtin.assert:
+            that:
+              - splunkbase_token is defined
+              - splunkbase_token | length > 0
+            fail_msg: >-
+              Splunkbase login returned no session token. Check
+              SPLUNKBASE_USERNAME / SPLUNKBASE_PASSWORD in Doppler.
+          when: splunkbase_to_sync | length > 0
 
-    - name: Remove downloaded archives from controller tmpdir
-      ansible.builtin.file:
-        path: "{{ splunkbase_sync_tmpdir }}/{{ item.filename }}"
-        state: absent
-      loop: "{{ splunkbase_to_sync }}"
-      loop_control:
-        label: "{{ item.filename }}"
+        - name: Download drifted entries from Splunkbase
+          ansible.builtin.get_url:
+            url: >-
+              {{ splunkbase_api }}/app/{{ item.splunkbase_id }}/release/{{ item.desired_version }}/download/
+            dest: "{{ splunkbase_sync_tmpdir }}/{{ item.filename }}"
+            headers:
+              X-Auth-Token: "{{ splunkbase_token }}"
+            force: true
+            mode: "0600"
+            timeout: 120
+          loop: "{{ splunkbase_to_sync }}"
+          loop_control:
+            label: "{{ item.filename }} v{{ item.desired_version }}"
 
-    - name: Summary
-      ansible.builtin.debug:
-        msg: >-
-          Splunkbase sync complete.
-          {{ splunkbase_to_sync | length }} of
-          {{ splunkbase_entries | length }} entries updated.
+        - name: Upload synced archives to MinIO
+          ansible.builtin.command:
+            cmd: >-
+              mc cp
+              {{ splunkbase_sync_tmpdir }}/{{ item.filename }}
+              homelab/{{ minio_bucket }}/{{ item.filename }}
+          environment: "{{ mc_env }}"
+          loop: "{{ splunkbase_to_sync }}"
+          loop_control:
+            label: "{{ item.filename }}"
+          changed_when: true
+
+        - name: Tag MinIO objects with version + splunkbase_id
+          ansible.builtin.command:
+            cmd: >-
+              mc tag set
+              homelab/{{ minio_bucket }}/{{ item.filename }}
+              version={{ item.desired_version }}&splunkbase_id={{ item.splunkbase_id }}
+          environment: "{{ mc_env }}"
+          loop: "{{ splunkbase_to_sync }}"
+          loop_control:
+            label: "{{ item.filename }}"
+          changed_when: true
+
+        - name: Remove downloaded archives from controller tmpdir
+          ansible.builtin.file:
+            path: "{{ splunkbase_sync_tmpdir }}/{{ item.filename }}"
+            state: absent
+          loop: "{{ splunkbase_to_sync }}"
+          loop_control:
+            label: "{{ item.filename }}"
+
+        # Manifest = the version bridge the air-gapped Splunk VM reads over HTTP.
+        # Written from the FULL resolved set (not just synced) so it always
+        # reflects what MinIO currently holds.
+        - name: Build manifest (app_dir → {version, filename})
+          ansible.builtin.set_fact:
+            splunkbase_manifest: >-
+              {{ splunkbase_manifest | default({}) | combine({
+                item.app_dir: {'version': item.desired_version, 'filename': item.filename}
+              }) }}
+          loop: "{{ splunkbase_desired }}"
+          loop_control:
+            label: "{{ item.app_dir }}"
+
+        - name: Write manifest to controller tmpdir
+          ansible.builtin.copy:
+            content: "{{ splunkbase_manifest | to_nice_json }}\n"
+            dest: "{{ splunkbase_sync_tmpdir }}/manifest.json"
+            mode: "0600"
+
+        - name: Publish manifest.json to MinIO
+          ansible.builtin.command:
+            cmd: >-
+              mc cp
+              {{ splunkbase_sync_tmpdir }}/manifest.json
+              homelab/{{ minio_bucket }}/manifest.json
+          environment: "{{ mc_env }}"
+          changed_when: true
+
+        - name: Remove manifest from controller tmpdir
+          ansible.builtin.file:
+            path: "{{ splunkbase_sync_tmpdir }}/manifest.json"
+            state: absent
+
+        - name: Summary
+          ansible.builtin.debug:
+            msg: >-
+              Splunkbase sync complete.
+              {{ splunkbase_to_sync | length }} of
+              {{ splunkbase_desired | length }} resolvable entries updated;
+              manifest.json published with {{ splunkbase_manifest | length }} apps.
+
+      rescue:
+        - name: Splunkbase sync failed — continue from existing MinIO contents (fail-soft)
+          ansible.builtin.debug:
+            msg: >-
+              Splunkbase resolve/sync failed; leaving MinIO + manifest.json as-is and
+              proceeding with whatever is already mirrored. Error:
+              {{ ansible_failed_result.msg | default('see preceding task') }}

--- a/roles/splunk_docker/tasks/apps.yml
+++ b/roles/splunk_docker/tasks/apps.yml
@@ -1,15 +1,21 @@
 ---
-# App installation tasks — installs every entry in splunk_docker_addons.
+# App installation tasks — installs/upgrades every entry in splunk_docker_addons.
 #
-# Target-side direct pull: the Splunk VM downloads each archive straight
+# Target-side direct pull: the air-gapped Splunk VM downloads each archive straight
 # from MinIO (or GitHub releases) via `ansible.builtin.unarchive` with
-# `remote_src: true`. The Ansible controller never stages archives —
-# MinIO is the single source of truth. `creates:` makes each task
-# idempotent by skipping when the extracted app directory already exists.
+# `remote_src: true`. The Ansible controller never stages archives — MinIO is the
+# single source of truth.
 #
-# VisiCore GitHub entries pin to `latest` intentionally — per the repo
-# dependency-versioning rule, JacobPEvans self-references use @main /
-# @latest, never SHA or version pins.
+# VERSION-AWARE (no install-once): MinIO-sourced apps are (re)extracted whenever the
+# version differs from what's installed, not merely when the dir is absent. The
+# desired version comes from `manifest.json` (published by sync-splunkbase.yml,
+# app_dir → {version, filename}); the installed version is recorded in a
+# `.minio_version` marker we write inside each app dir. This is what makes
+# "always updated to the latest" actually hold — the old `creates:` guard froze
+# every app at its first-installed version forever.
+#
+# Manual apps (no manifest entry, e.g. Slack/Automox) fall back to install-if-missing.
+# VisiCore GitHub entries still use `creates:` (separate air-gap follow-up).
 
 - name: Load Splunk add-on registry
   ansible.builtin.include_vars:
@@ -24,18 +30,116 @@
     group: "{{ splunk_docker_group }}"
     mode: '0755'
 
-- name: Install Splunk add-ons from MinIO
+# --- MinIO-sourced apps: version-aware install/upgrade ---
+
+- name: Fetch the MinIO add-on version manifest
+  ansible.builtin.uri:
+    url: "{{ splunk_docker_artifact_base_url }}/manifest.json"
+    method: GET
+    return_content: true
+    status_code: [200, 403, 404]
+  register: splunk_docker_minio_manifest_q
+  changed_when: false
+  failed_when: false
+
+# Empty when the manifest is absent (no sync has run yet) — every MinIO app then
+# falls back to install-if-missing, exactly like the legacy behaviour.
+- name: Parse the version manifest (empty when absent/unreadable)
+  ansible.builtin.set_fact:
+    splunk_docker_minio_manifest: >-
+      {{ (splunk_docker_minio_manifest_q.content | from_json)
+         if (splunk_docker_minio_manifest_q.status | default(0)) == 200
+            and (splunk_docker_minio_manifest_q.content | default('')) | length > 0
+         else {} }}
+
+- name: Build the MinIO-sourced add-on list
+  ansible.builtin.set_fact:
+    splunk_docker_minio_addons: "{{ splunk_docker_addons | rejectattr('github_repo', 'defined') | list }}"
+
+- name: Read installed version markers
+  ansible.builtin.slurp:
+    src: "{{ splunk_docker_etc_dir }}/apps/{{ item.app_dir }}/.minio_version"
+  register: splunk_docker_minio_markers
+  loop: "{{ splunk_docker_minio_addons }}"
+  loop_control:
+    label: "{{ item.app_dir }}"
+  failed_when: false  # missing marker → not installed (or legacy install)
+
+# needs_install when:
+#   manifest app (desired != ''): installed version differs from desired
+#   manual  app (desired == ''):  not yet installed
+- name: Compute install/upgrade decisions
+  ansible.builtin.set_fact:
+    splunk_docker_minio_plan: >-
+      {{ splunk_docker_minio_plan | default([]) + [item.0 | combine({
+        'desired_version': (splunk_docker_minio_manifest[item.0.app_dir].version | default('')),
+        'installed_version': (
+          (item.1.content | b64decode | trim) if item.1.content is defined else ''
+        ),
+      })] }}
+  loop: "{{ splunk_docker_minio_addons | zip(splunk_docker_minio_markers.results) | list }}"
+  loop_control:
+    label: "{{ item.0.app_dir }}"
+
+# selectattr can't compare two attributes to each other, so the decision is
+# computed per-item into a bool flag here.
+- name: Mark each app's install need
+  ansible.builtin.set_fact:
+    splunk_docker_minio_decided: >-
+      {{ splunk_docker_minio_decided | default([]) + [item | combine({
+        '_needs_install': (
+          (item.desired_version != '' and item.desired_version != item.installed_version)
+          or (item.desired_version == '' and item.installed_version == '')
+        )
+      })] }}
+  loop: "{{ splunk_docker_minio_plan }}"
+  loop_control:
+    label: "{{ item.app_dir }}"
+
+- name: Show install/upgrade decisions
+  ansible.builtin.debug:
+    msg: >-
+      {{ item.app_dir }}: desired={{ item.desired_version or '(manual)' }}
+      installed={{ item.installed_version or '(none)' }}
+      → {{ 'INSTALL' if item._needs_install else 'skip' }}
+  loop: "{{ splunk_docker_minio_decided }}"
+  loop_control:
+    label: "{{ item.app_dir }}"
+
+# Clean upgrade: drop the old tree first so files removed upstream don't linger.
+# Only when an actual prior version exists (fresh installs have nothing to remove).
+- name: Remove the old app directory before upgrade
+  ansible.builtin.file:
+    path: "{{ splunk_docker_etc_dir }}/apps/{{ item.app_dir }}"
+    state: absent
+  loop: "{{ splunk_docker_minio_decided | selectattr('_needs_install') | selectattr('installed_version', 'ne', '') | list }}"
+  loop_control:
+    label: "{{ item.app_dir }}"
+
+- name: Install/upgrade Splunk add-ons from MinIO
   ansible.builtin.unarchive:
     src: "{{ splunk_docker_artifact_base_url }}/{{ item.filename }}"
     dest: "{{ splunk_docker_etc_dir }}/apps/"
     owner: "{{ splunk_docker_user }}"
     group: "{{ splunk_docker_group }}"
     remote_src: true
-    creates: "{{ splunk_docker_etc_dir }}/apps/{{ item.app_dir }}"
-  loop: "{{ splunk_docker_addons | rejectattr('github_repo', 'defined') | list }}"
+  loop: "{{ splunk_docker_minio_decided | selectattr('_needs_install') | list }}"
+  loop_control:
+    label: "{{ item.app_dir }} v{{ item.desired_version | default('manual') }}"
+  notify: Restart Splunk container
+
+- name: Record installed version markers
+  ansible.builtin.copy:
+    content: "{{ item.desired_version or 'manual' }}\n"
+    dest: "{{ splunk_docker_etc_dir }}/apps/{{ item.app_dir }}/.minio_version"
+    owner: "{{ splunk_docker_user }}"
+    group: "{{ splunk_docker_group }}"
+    mode: '0644'
+  loop: "{{ splunk_docker_minio_decided | selectattr('_needs_install') | list }}"
   loop_control:
     label: "{{ item.app_dir }}"
-  notify: Restart Splunk container
+
+# --- GitHub-release apps (VisiCore) — unchanged; see air-gap follow-up ---
 
 - name: Install Splunk add-ons from GitHub Releases
   ansible.builtin.unarchive:

--- a/roles/splunk_docker/tasks/apps.yml
+++ b/roles/splunk_docker/tasks/apps.yml
@@ -32,6 +32,12 @@
 
 # --- MinIO-sourced apps: version-aware install/upgrade ---
 
+- name: Build the MinIO-sourced add-on list
+  ansible.builtin.set_fact:
+    splunk_docker_minio_addons: "{{ splunk_docker_addons | rejectattr('github_repo', 'defined') | list }}"
+
+# Gated on a non-empty list so Molecule (which sets splunk_docker_addons: []) never
+# templates splunk_docker_artifact_base_url / tofu_data, which it does not provide.
 - name: Fetch the MinIO add-on version manifest
   ansible.builtin.uri:
     url: "{{ splunk_docker_artifact_base_url }}/manifest.json"
@@ -41,9 +47,10 @@
   register: splunk_docker_minio_manifest_q
   changed_when: false
   failed_when: false
+  when: splunk_docker_minio_addons | length > 0
 
-# Empty when the manifest is absent (no sync has run yet) — every MinIO app then
-# falls back to install-if-missing, exactly like the legacy behaviour.
+# Empty when the manifest is absent/skipped (no sync has run yet, or no MinIO apps)
+# — every MinIO app then falls back to install-if-missing, like the legacy behaviour.
 - name: Parse the version manifest (empty when absent/unreadable)
   ansible.builtin.set_fact:
     splunk_docker_minio_manifest: >-
@@ -51,10 +58,6 @@
          if (splunk_docker_minio_manifest_q.status | default(0)) == 200
             and (splunk_docker_minio_manifest_q.content | default('')) | length > 0
          else {} }}
-
-- name: Build the MinIO-sourced add-on list
-  ansible.builtin.set_fact:
-    splunk_docker_minio_addons: "{{ splunk_docker_addons | rejectattr('github_repo', 'defined') | list }}"
 
 - name: Read installed version markers
   ansible.builtin.slurp:
@@ -64,6 +67,12 @@
   loop_control:
     label: "{{ item.app_dir }}"
   failed_when: false  # missing marker → not installed (or legacy install)
+
+# Initialise accumulators so they stay defined when the loop is empty (Molecule).
+- name: Initialise MinIO install accumulators
+  ansible.builtin.set_fact:
+    splunk_docker_minio_plan: []
+    splunk_docker_minio_decided: []
 
 # needs_install when:
 #   manifest app (desired != ''): installed version differs from desired

--- a/roles/splunk_docker/vars/addons.yml
+++ b/roles/splunk_docker/vars/addons.yml
@@ -2,13 +2,17 @@
 # Splunk Add-on Registry
 #
 # Fields:
-#   filename       — archive name (in MinIO bucket, or github release asset)
-#   app_dir        — extracted directory name under /opt/splunk/etc/apps/
+#   filename       — archive name (in MinIO bucket, or github release asset).
+#                    Version-free by convention; extension is cosmetic
+#                    (ansible.builtin.unarchive auto-detects gzip content).
+#   app_dir        — extracted directory name under /opt/splunk/etc/apps/.
+#                    Equals the Splunkbase `appid` for splunkbase entries.
 #   splunkbase_id  — Splunkbase numeric app ID. When present, playbooks/sync-splunkbase.yml
-#                    uses it to mirror the pinned version into MinIO. When absent, the
-#                    entry is skipped by the sync and must be populated manually.
-#   version        — pinned version string. Used both as the Splunkbase download URL
-#                    path segment and as the `version` tag on the MinIO object.
+#                    resolves the LATEST release from the public Splunkbase API and
+#                    mirrors it into MinIO. When absent, the entry is skipped by the
+#                    sync and must be populated manually.
+#   pin_version    — optional. Hard-pin to an exact version string to hold back a bad
+#                    release. When absent (the default), the entry tracks latest.
 #   github_repo    — optional. If set, download from github.com/<repo> releases/latest.
 #                    Mutually exclusive with splunkbase_id.
 #   role           — optional. Stable identifier for entries that other playbooks
@@ -16,35 +20,38 @@
 #                    is used by validate.yml + tasks/mcp_server.yml so the filename
 #                    can change without breaking either lookup).
 #
-# Runtime install (roles/splunk_docker/tasks/apps.yml) reads filename + app_dir.
-# Sync automation (playbooks/sync-splunkbase.yml) reads splunkbase_id + version
-# + filename and uses the Doppler-injected SPLUNKBASE_USERNAME / SPLUNKBASE_PASSWORD
-# to fetch archives. Bump `version` here → re-run sync → Splunk VM picks up on next
-# deploy. No manual downloads ever.
+# Flow: sync-splunkbase.yml (control node, has internet) resolves the latest version
+# per splunkbase_id, downloads it, mirrors it to the MinIO `splunk-addons` bucket, and
+# writes manifest.json mapping app_dir → version. The air-gapped Splunk VM then reads
+# manifest.json over the LAN and re-extracts any app whose installed version differs
+# (roles/splunk_docker/tasks/apps.yml). No manual downloads; no version bumps here —
+# add `pin_version` only to deliberately freeze a single app.
 
 splunk_docker_addons:
-  # --- MinIO, Splunkbase-sourced (auto-sync) ---
-  - {filename: TA-unifi-cloud.tar, app_dir: TA-unifi-cloud, splunkbase_id: 7494, version: "1.0.2"}
-  - {filename: duck-yeah.tar, app_dir: DuckYeah, splunkbase_id: 7015, version: "2.3.4"}
-  - {filename: splunk-db-connect.tar, app_dir: splunk_app_db_connect, splunkbase_id: 2686, version: "4.2.3"}
-  - {filename: Splunk_TA_H3_Unifi.tar, app_dir: Splunk_TA_H3_Unifi, splunkbase_id: 7935, version: "1.0.0"}
-  - {filename: ubiquiti-add-on-for-splunk.tar, app_dir: TA-ubiquiti, splunkbase_id: 4107, version: "1.3.6"}
-  - {filename: splunk-mcp-server.tar, app_dir: Splunk_MCP_Server, splunkbase_id: 7931, version: "1.1.0", role: mcp_server}
-  - {filename: python-for-scientific-computing-for-linux-64-bit.tar, app_dir: Splunk_SA_Scientific_Python_linux_x86_64, splunkbase_id: 2882, version: "4.3.1"}
-  - {filename: splunk-ai-toolkit.tar, app_dir: Splunk_ML_Toolkit, splunkbase_id: 2890, version: "5.7.2"}
-  - {filename: mltk-container.tar, app_dir: mltk-container, splunkbase_id: 4607, version: "5.2.3"}
-  - {filename: splunk-ai-assistant.tar, app_dir: Splunk_AI_Assistant_Cloud, splunkbase_id: 7245, version: "2.0.0"}
-  - {filename: alerts-for-splunk-admins.tar, app_dir: SplunkAdmins, splunkbase_id: 3796, version: "4.0.7"}
-  - {filename: admin-ninja-app.tar, app_dir: admin_ninja_app, splunkbase_id: 6664, version: "1.0.4"}
-  - {filename: admin-ninja-ta.tar, app_dir: TA_admin_ninja, splunkbase_id: 6665, version: "1.0.3"}
-  - {filename: admin-pilot-for-splunk-ap4s.tar, app_dir: insights_app_splunk, splunkbase_id: 6489, version: "1.1.13"}
-  - {filename: splunk-app-for-chargeback.tar, app_dir: chargeback_app_splunk_cloud, splunkbase_id: 5688, version: "2.0.59"}
-  - {filename: sa-littlehelper.spl, app_dir: sa-littlehelper, splunkbase_id: 6368, version: "1.6.1"}
-  - {filename: Splunk_TA_paloalto_networks.tar, app_dir: Splunk_TA_paloalto_networks, splunkbase_id: 7523, version: "3.0.0"}
-  - {filename: splunk-add-on-for-microsoft-office-365.spl, app_dir: splunk_ta_o365, splunkbase_id: 4055, version: "6.0.0"}
-  - {filename: splunk-add-on-for-servicenow.spl, app_dir: Splunk_TA_snow, splunkbase_id: 1928, version: "10.0.0"}
-  - {filename: hurricane-labs-app-for-shodan.tar, app_dir: Hurricane_Labs_App_for_Shodan, splunkbase_id: 1767, version: "2.2.6"}
-  - {filename: hurricane-labs-add-on-for-windows-powershell-transcript.tar, app_dir: TA-powershell_transcript, splunkbase_id: 4984, version: "0.1.3"}
+  # --- MinIO, Splunkbase-sourced (auto-sync, tracks latest) ---
+  - {filename: TA-unifi-cloud.tar, app_dir: TA-unifi-cloud, splunkbase_id: 7494}
+  - {filename: duck-yeah.tar, app_dir: DuckYeah, splunkbase_id: 7015}
+  - {filename: splunk-db-connect.tar, app_dir: splunk_app_db_connect, splunkbase_id: 2686}
+  - {filename: Splunk_TA_H3_Unifi.tar, app_dir: Splunk_TA_H3_Unifi, splunkbase_id: 7935}
+  - {filename: ubiquiti-add-on-for-splunk.tar, app_dir: TA-ubiquiti, splunkbase_id: 4107}
+  - {filename: splunk-mcp-server.tar, app_dir: Splunk_MCP_Server, splunkbase_id: 7931, role: mcp_server}
+  - {filename: python-for-scientific-computing-for-linux-64-bit.tar, app_dir: Splunk_SA_Scientific_Python_linux_x86_64, splunkbase_id: 2882}
+  - {filename: splunk-ai-toolkit.tar, app_dir: Splunk_ML_Toolkit, splunkbase_id: 2890}
+  - {filename: mltk-container.tar, app_dir: mltk-container, splunkbase_id: 4607}
+  - {filename: ai-workbench-adjutant-ai.tar, app_dir: itmip_ai_splunk_assistent_app, splunkbase_id: 8747}
+  - {filename: genai-observability-for-splunk.tar, app_dir: splunk_genai_observability, splunkbase_id: 8308}
+  - {filename: splunk-ai-assistant.tar, app_dir: Splunk_AI_Assistant_Cloud, splunkbase_id: 7245}
+  - {filename: alerts-for-splunk-admins.tar, app_dir: SplunkAdmins, splunkbase_id: 3796}
+  - {filename: admin-ninja-app.tar, app_dir: admin_ninja_app, splunkbase_id: 6664}
+  - {filename: admin-ninja-ta.tar, app_dir: TA_admin_ninja, splunkbase_id: 6665}
+  - {filename: admin-pilot-for-splunk-ap4s.tar, app_dir: insights_app_splunk, splunkbase_id: 6489}
+  - {filename: splunk-app-for-chargeback.tar, app_dir: chargeback_app_splunk_cloud, splunkbase_id: 5688}
+  - {filename: sa-littlehelper.spl, app_dir: sa-littlehelper, splunkbase_id: 6368}
+  - {filename: Splunk_TA_paloalto_networks.tar, app_dir: Splunk_TA_paloalto_networks, splunkbase_id: 7523}
+  - {filename: splunk-add-on-for-microsoft-office-365.spl, app_dir: splunk_ta_o365, splunkbase_id: 4055}
+  - {filename: splunk-add-on-for-servicenow.spl, app_dir: Splunk_TA_snow, splunkbase_id: 1928}
+  - {filename: hurricane-labs-app-for-shodan.tar, app_dir: Hurricane_Labs_App_for_Shodan, splunkbase_id: 1767}
+  - {filename: hurricane-labs-add-on-for-windows-powershell-transcript.tar, app_dir: TA-powershell_transcript, splunkbase_id: 4984}
 
   # --- MinIO, no Splunkbase match (manual upload; sync skips) ---
   # Hurricane Labs' Automox add-on was removed from Splunkbase. The archive is


### PR DESCRIPTION
## Why

The homelab is meant to keep Splunk fully air-gapped while always running the latest Splunkbase apps. In reality apps were badly stale and two requested apps weren't installed. Live MCP read of the running Splunk confirmed the baseline:

| ID | App | Installed | Latest |
|----|-----|-----------|--------|
| 2890 | Splunk AI Toolkit (`Splunk_ML_Toolkit`) | **5.7.2** | 5.7.4 |
| 4607 | DSDL (`mltk-container`) | **5.2.3** | 5.2.4 |
| 8747 | AI Workbench (`itmip_ai_splunk_assistent_app`) | **absent** | 1.4.2 |
| 8308 | GenAI Observability (`splunk_genai_observability`) | **absent** | 2.0.0 |

Three compounding causes — **all in this repo**. The air-gap firewall (`terraform-proxmox`: Splunk VM + MinIO are RFC1918-only; the control node has egress) and MinIO (`ansible-proxmox-apps`: `splunk-addons` bucket, anonymous-read, versioned) were already correct and need no changes.

## Root causes & fixes

1. **Install-once bug (dominant)** — `apps.yml` extracted with `creates: apps/{{app_dir}}`, so an installed app was **never re-extracted**; even a perfect MinIO sync couldn't update it. Now **version-aware**: read `manifest.json` + a `.minio_version` marker, re-extract only when the version differs. Manual apps keep install-if-missing.
2. **Pinned, never bumped** — `addons.yml` pinned versions and `sync-splunkbase.yml` downloaded exactly those. Now every entry **tracks latest**: the sync resolves each app's newest release from the **public** Splunkbase API (`/api/v1/app/{id}/release/` → `[0].name`; no auth for resolution), with a `pin_version` escape hatch. Added 8747 + 8308 (app_dir taken from the API's `appid`).
3. **Manual + decoupled** — `sync-splunkbase.yml` ran only by hand. Now `site.yml` runs it as an **in-flow localhost pre-play** before deploy, so every run installs current apps.

## Air-gap preserved

Resolution + download happen **only on the controller** (internet egress); the Splunk VM only ever pulls archives + `manifest.json` from MinIO over the LAN. The sync is wrapped in `block`/`rescue` — **fail-soft**: if Splunkbase is unreachable the deploy proceeds from current MinIO contents.

## Manifest as the version bridge

MinIO object tags aren't visible over a bare HTTP GET, so the sync publishes `splunk-addons/manifest.json` (`app_dir → {version, filename}`). The air-gapped VM reads it to decide what to (re)extract.

## Verification

- `ansible-lint` (production) + `ansible-playbook playbooks/site.yml --syntax-check` clean.
- Offline-validated the non-trivial Jinja: latest-version parse, `needs_install` truth table (upgrade/current/fresh/manual), manifest default lookup, selectattr-truthy.
- Splunkbase resolution API confirmed live (returns 5.7.4 / 5.2.4 / 1.4.2 / 2.0.0).
- Live MCP read confirmed the stale/missing baseline above.

### Remaining step (live; mutates the homelab — MinIO write + Splunk restart)
```
doppler run -- ansible-playbook playbooks/site.yml
```
Then re-read installed apps (Splunk MCP `get_knowledge_objects type=apps`) and confirm the four show 5.7.4 / 5.2.4 / 1.4.2 / 2.0.0; a second run should be a no-op (idempotent by version).

## Out of scope (follow-ups)
- **Scheduling** the recurring run — a GitHub-hosted runner can't reach the RFC1918 LAN, so it must be a self-hosted runner cron or a control-node systemd timer. Decide next.
- **VisiCore GitHub-release apps** fetch from `github.com` on the air-gapped VM (can't actually reach it) and still have the install-once `creates:` guard — should be mirrored through MinIO. Separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)