### PR TITLE
fix(splunk): repoint Splunkbase sync MinIO → object-storage (RustFS)

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -6,13 +6,14 @@
 - name: Load OpenTofu inventory
   ansible.builtin.import_playbook: ../inventory/load_tofu.yml
 
-# Resolve the latest Splunkbase app versions and mirror them into MinIO BEFORE
-# deploying, so every run installs current apps. Runs entirely on the controller
-# (which has internet egress); the Splunk VM stays air-gapped and only pulls from
-# MinIO. Fail-soft: a Splunkbase outage is rescued inside this playbook and the
-# deploy proceeds from whatever MinIO already holds. Requires the Splunkbase +
-# MinIO secrets in the environment (provided by `doppler run --`).
-- name: Sync latest Splunkbase apps into MinIO (in-flow, fail-soft)
+# Resolve the latest Splunkbase app versions and mirror them into the
+# object-storage bucket BEFORE deploying, so every run installs current apps. Runs
+# entirely on the controller (which has internet egress); the Splunk VM stays
+# air-gapped and only pulls from object storage. Fail-soft: a Splunkbase outage is
+# rescued inside this playbook and the deploy proceeds from whatever the bucket
+# already holds. Requires the Splunkbase + object-storage secrets in the
+# environment (provided by `doppler run --`).
+- name: Sync latest Splunkbase apps into object storage (in-flow, fail-soft)
   ansible.builtin.import_playbook: sync-splunkbase.yml
 
 # Configure NTP time synchronization BEFORE deploying Splunk. Splunk's

--- a/playbooks/sync-splunkbase.yml
+++ b/playbooks/sync-splunkbase.yml
@@ -118,7 +118,9 @@
                   item.0.pin_version if item.0.pin_version is defined
                   else (
                     (item.1.content | from_json | first).name
-                    if (item.1.status | default(0)) == 200 and (item.1.content | default('')) | length > 0
+                    if (item.1.status | default(0)) == 200
+                       and (item.1.content | default('') | trim)[:1] == '['
+                       and (item.1.content | from_json | length) > 0
                     else ''
                   )
                 )
@@ -220,7 +222,8 @@
             splunkbase_token: >-
               {{ splunkbase_login.content
                  | regex_search('<id>([^<]+)</id>', '\1')
-                 | first }}
+                 | default([], true)
+                 | first | default('') }}
           when: splunkbase_to_sync | length > 0
           no_log: true
 

--- a/playbooks/sync-splunkbase.yml
+++ b/playbooks/sync-splunkbase.yml
@@ -1,24 +1,28 @@
 ---
-# Splunkbase → MinIO sync playbook (resolves LATEST, mirrors, writes manifest)
+# Splunkbase → object-storage (RustFS) sync playbook — resolves LATEST, mirrors, writes manifest
 #
 # For every addons.yml entry with a `splunkbase_id`, resolves the latest release
 # from the PUBLIC Splunkbase API (no auth needed for resolution), downloads it with
-# the authenticated session, and mirrors it into the `splunk-addons` MinIO bucket
-# tagged `version=X.Y.Z&splunkbase_id=NNNN`. Finally writes `manifest.json`
-# (app_dir → {version, filename}) to the bucket — the version bridge the air-gapped
-# Splunk VM reads over the LAN to know which apps to (re)extract.
+# the authenticated session, and mirrors it into the `splunk-addons` bucket on the
+# RustFS object-storage LXC, tagged `version=X.Y.Z&splunkbase_id=NNNN`. Finally
+# writes `manifest.json` (app_dir → {version, filename}) to the bucket — the version
+# bridge the air-gapped Splunk VM reads over the LAN to know which apps to (re)extract.
 #
 # `pin_version` on an entry overrides resolution (hold back a bad release).
 #
-# Idempotent: skips download when the MinIO `version` tag already matches the
+# Versions are kept over time for free: the `splunk-addons` bucket has
+# object-versioning enabled, so each overwrite of an app retains the prior version
+# as a noncurrent version — no extra bookkeeping here.
+#
+# Idempotent: skips download when the bucket `version` tag already matches the
 # resolved latest. Fail-soft: if Splunkbase is unreachable, the whole resolve/sync
-# block is rescued — the existing MinIO contents + manifest are left intact so a
+# block is rescued — the existing bucket contents + manifest are left intact so a
 # deploy can still proceed. This playbook also runs as an in-flow pre-play of
 # site.yml; it stays usable standalone for manual/scheduled syncs.
 #
 # Credentials (Doppler):
-#   SPLUNKBASE_USERNAME / SPLUNKBASE_PASSWORD — Splunkbase account (download only)
-#   MINIO_ROOT_USER     / MINIO_ROOT_PASSWORD — MinIO bucket write auth
+#   SPLUNKBASE_USERNAME      / SPLUNKBASE_PASSWORD          — Splunkbase account (download only)
+#   OBJECT_STORAGE_ROOT_USER / OBJECT_STORAGE_ROOT_PASSWORD — object-storage bucket write auth
 #
 # Usage:
 #   doppler run -- ansible-playbook playbooks/sync-splunkbase.yml
@@ -26,24 +30,24 @@
 # Runs entirely on localhost (the Ansible controller, which has internet egress).
 # The Splunk VM never contacts Splunkbase — air-gap preserved.
 
-- name: Load OpenTofu inventory (for MinIO endpoint)
+- name: Load OpenTofu inventory (for object-storage endpoint)
   ansible.builtin.import_playbook: ../inventory/load_tofu.yml
 
-- name: Mirror latest Splunkbase add-ons into MinIO
+- name: Mirror latest Splunkbase add-ons into object storage
   hosts: localhost
   connection: local
   gather_facts: false
   vars:
     splunkbase_api: "{{ splunkbase_api_url | default('https://splunkbase.splunk.com') }}"
     splunkbase_sync_tmpdir: /tmp/splunkbase-sync
-    minio_bucket: splunk-addons
+    object_storage_bucket: splunk-addons
     # mc resolves the `homelab` alias from this env var — no persisted alias file.
     mc_env:
       MC_HOST_homelab: >-
-        http://{{ lookup('env', 'MINIO_ROOT_USER') }}:{{
-        lookup('env', 'MINIO_ROOT_PASSWORD') }}@{{
-        hostvars['localhost']['tofu_data']['containers']['minio']['ip'] }}:{{
-        hostvars['localhost']['tofu_data']['constants']['service_ports']['minio_api'] }}
+        http://{{ lookup('env', 'OBJECT_STORAGE_ROOT_USER') }}:{{
+        lookup('env', 'OBJECT_STORAGE_ROOT_PASSWORD') }}@{{
+        hostvars['localhost']['tofu_data']['containers']['object-storage']['ip'] }}:{{
+        hostvars['localhost']['tofu_data']['constants']['service_ports']['object_storage_s3'] }}
 
   tasks:
     - name: Assert required environment variables are set
@@ -51,11 +55,11 @@
         that:
           - lookup('env', 'SPLUNKBASE_USERNAME') | length > 0
           - lookup('env', 'SPLUNKBASE_PASSWORD') | length > 0
-          - lookup('env', 'MINIO_ROOT_USER') | length > 0
-          - lookup('env', 'MINIO_ROOT_PASSWORD') | length > 0
+          - lookup('env', 'OBJECT_STORAGE_ROOT_USER') | length > 0
+          - lookup('env', 'OBJECT_STORAGE_ROOT_PASSWORD') | length > 0
         fail_msg: >-
           Missing one of SPLUNKBASE_USERNAME, SPLUNKBASE_PASSWORD,
-          MINIO_ROOT_USER, MINIO_ROOT_PASSWORD. Run via
+          OBJECT_STORAGE_ROOT_USER, OBJECT_STORAGE_ROOT_PASSWORD. Run via
           `doppler run -- ansible-playbook …` so Doppler injects secrets.
 
     - name: Load Splunk add-on registry
@@ -88,7 +92,7 @@
 
     # Resolve → download → mirror → manifest. Wrapped in block/rescue so a
     # Splunkbase outage degrades gracefully: the deploy continues from whatever
-    # MinIO already holds (the existing manifest is left untouched).
+    # the object store already holds (the existing manifest is left untouched).
     - name: Resolve latest, sync drifted apps, and publish manifest
       block:
         # PUBLIC endpoint — no auth. Newest release is element [0].
@@ -140,14 +144,14 @@
         # `mc tag list --json` returns nonzero for a missing object ("NoSuchKey"
         # in stdout) — expected, drives a sync. Any other nonzero (auth/network/
         # bucket) must fail loud, validated in the next task.
-        - name: Query current MinIO version tag for each entry
+        - name: Query current object-storage version tag for each entry
           ansible.builtin.command:
-            cmd: "mc tag list --json homelab/{{ minio_bucket }}/{{ item.filename }}"
+            cmd: "mc tag list --json homelab/{{ object_storage_bucket }}/{{ item.filename }}"
           environment: "{{ mc_env }}"
           loop: "{{ splunkbase_desired }}"
           loop_control:
             label: "{{ item.filename }}"
-          register: minio_tag_query
+          register: object_storage_tag_query
           changed_when: false
           failed_when: false
           no_log: true
@@ -158,14 +162,14 @@
               - item.rc == 0 or 'NoSuchKey' in (item.stdout | default(''))
             fail_msg: >-
               mc tag list failed for {{ item.item.filename }} with rc={{ item.rc }}.
-              Not a "missing object" — check MinIO connectivity,
-              MINIO_ROOT_USER/PASSWORD, and bucket existence.
+              Not a "missing object" — check object-storage connectivity,
+              OBJECT_STORAGE_ROOT_USER/PASSWORD, and bucket existence.
             quiet: true
-          loop: "{{ minio_tag_query.results }}"
+          loop: "{{ object_storage_tag_query.results }}"
           loop_control:
             label: "{{ item.item.filename }}"
 
-        - name: Compute sync decisions (MinIO tag vs resolved latest)
+        - name: Compute sync decisions (bucket tag vs resolved latest)
           ansible.builtin.set_fact:
             splunkbase_plan: >-
               {{ splunkbase_plan | default([]) + [item.item | combine({
@@ -179,7 +183,7 @@
                       | default('') | trim) != (item.item.desired_version | string | trim)
                 ),
               })] }}
-          loop: "{{ minio_tag_query.results }}"
+          loop: "{{ object_storage_tag_query.results }}"
           loop_control:
             label: "{{ item.item.filename }}"
 
@@ -187,7 +191,7 @@
           ansible.builtin.debug:
             msg: >-
               {{ item.filename }}: latest={{ item.desired_version }}
-              minio={{ item.current_version or '(none)' }}
+              store={{ item.current_version or '(none)' }}
               → {{ 'SYNC' if item.needs_sync else 'skip' }}
           loop: "{{ splunkbase_plan }}"
           loop_control:
@@ -244,23 +248,23 @@
           loop_control:
             label: "{{ item.filename }} v{{ item.desired_version }}"
 
-        - name: Upload synced archives to MinIO
+        - name: Upload synced archives to object storage
           ansible.builtin.command:
             cmd: >-
               mc cp
               {{ splunkbase_sync_tmpdir }}/{{ item.filename }}
-              homelab/{{ minio_bucket }}/{{ item.filename }}
+              homelab/{{ object_storage_bucket }}/{{ item.filename }}
           environment: "{{ mc_env }}"
           loop: "{{ splunkbase_to_sync }}"
           loop_control:
             label: "{{ item.filename }}"
           changed_when: true
 
-        - name: Tag MinIO objects with version + splunkbase_id
+        - name: Tag object-storage objects with version + splunkbase_id
           ansible.builtin.command:
             cmd: >-
               mc tag set
-              homelab/{{ minio_bucket }}/{{ item.filename }}
+              homelab/{{ object_storage_bucket }}/{{ item.filename }}
               version={{ item.desired_version }}&splunkbase_id={{ item.splunkbase_id }}
           environment: "{{ mc_env }}"
           loop: "{{ splunkbase_to_sync }}"
@@ -278,7 +282,7 @@
 
         # Manifest = the version bridge the air-gapped Splunk VM reads over HTTP.
         # Written from the FULL resolved set (not just synced) so it always
-        # reflects what MinIO currently holds.
+        # reflects what the bucket currently holds.
         - name: Build manifest (app_dir → {version, filename})
           ansible.builtin.set_fact:
             splunkbase_manifest: >-
@@ -295,12 +299,12 @@
             dest: "{{ splunkbase_sync_tmpdir }}/manifest.json"
             mode: "0600"
 
-        - name: Publish manifest.json to MinIO
+        - name: Publish manifest.json to object storage
           ansible.builtin.command:
             cmd: >-
               mc cp
               {{ splunkbase_sync_tmpdir }}/manifest.json
-              homelab/{{ minio_bucket }}/manifest.json
+              homelab/{{ object_storage_bucket }}/manifest.json
           environment: "{{ mc_env }}"
           changed_when: true
 
@@ -318,9 +322,9 @@
               manifest.json published with {{ splunkbase_manifest | length }} apps.
 
       rescue:
-        - name: Splunkbase sync failed — continue from existing MinIO contents (fail-soft)
+        - name: Splunkbase sync failed — continue from existing object-storage contents (fail-soft)
           ansible.builtin.debug:
             msg: >-
-              Splunkbase resolve/sync failed; leaving MinIO + manifest.json as-is and
+              Splunkbase resolve/sync failed; leaving the bucket + manifest.json as-is and
               proceeding with whatever is already mirrored. Error:
               {{ ansible_failed_result.msg | default('see preceding task') }}

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -175,13 +175,15 @@ splunk_docker_java_container_home: "/opt/java"
 splunk_docker_mssql_driver_enabled: false
 splunk_docker_mssql_driver_version: "12.8.1.jre11"
 
-# Artifact store (MinIO)
+# Artifact store (object-storage / RustFS)
 # Custom add-ons with artifact_store: true are downloaded from this URL.
-# MinIO bucket has anonymous read policy on internal network (no auth needed).
-# IP and port come from tofu inventory — no hardcoded values.
+# The splunk-addons bucket has an anonymous read policy on the internal network
+# (no auth needed). IP and port come from tofu inventory — no hardcoded values.
+# The container key is hyphenated, so bracket notation is required (dot notation
+# would mis-parse `object-storage` as subtraction).
 splunk_docker_artifact_base_url: >-
-  http://{{ tofu_data.containers.minio.ip }}:{{
-  tofu_data.constants.service_ports.minio_api }}/splunk-addons
+  http://{{ tofu_data.containers['object-storage'].ip }}:{{
+  tofu_data.constants.service_ports.object_storage_s3 }}/splunk-addons
 # VisiCore TA and App are downloaded from GitHub Releases (latest) automatically.
-# MinIO-sourced add-ons use version-free filenames — versions are tracked
-# exclusively via MinIO object tags (bucket versioning enabled).
+# object-storage-sourced add-ons use version-free filenames — current version is
+# tracked via the object tag, and prior versions are retained by bucket versioning.

--- a/roles/splunk_docker/tasks/apps.yml
+++ b/roles/splunk_docker/tasks/apps.yml
@@ -56,7 +56,7 @@
     splunk_docker_minio_manifest: >-
       {{ (splunk_docker_minio_manifest_q.content | from_json)
          if (splunk_docker_minio_manifest_q.status | default(0)) == 200
-            and (splunk_docker_minio_manifest_q.content | default('')) | length > 0
+            and (splunk_docker_minio_manifest_q.content | default('') | trim)[:1] == '{'
          else {} }}
 
 - name: Read installed version markers
@@ -81,7 +81,7 @@
   ansible.builtin.set_fact:
     splunk_docker_minio_plan: >-
       {{ splunk_docker_minio_plan | default([]) + [item.0 | combine({
-        'desired_version': (splunk_docker_minio_manifest[item.0.app_dir].version | default('')),
+        'desired_version': ((splunk_docker_minio_manifest[item.0.app_dir] | default({})).version | default('')),
         'installed_version': (
           (item.1.content | b64decode | trim) if item.1.content is defined else ''
         ),


### PR DESCRIPTION
# fix(splunk): repoint Splunkbase sync from MinIO to object-storage (RustFS)

> ## ⛔ DO NOT MERGE YET — held until RustFS is serving
> RustFS is **not installed/serving** yet (the `object_storage` role converge,
> data migration, and DNS/reservation are still pending). Merging + converging
> this now would point `splunk_docker_artifact_base_url` at a dead endpoint and
> **break Splunk app installs**. MinIO remains the live store until cutover.
> **Merge as part of the RustFS cutover** (after RustFS is up + data migrated).
> This PR is otherwise ready: rebased onto `main`, CI green, no open threads.

## Why

The Splunkbase pipeline still targeted the **deprecated MinIO** LXC — both the
writer (`sync-splunkbase.yml`) and the reader (`splunk_docker_artifact_base_url`).
The replacement RustFS `object-storage` container's `splunk-addons` bucket has
**object-versioning enabled**, so repointing also gives free version history.

## What

- Writer + reader point at `containers['object-storage']` / `object_storage_s3`
  instead of `minio` / `minio_api` (bracket notation — the key is hyphenated).
- Credential env vars `MINIO_ROOT_*` → `OBJECT_STORAGE_ROOT_*`.
- Full de-minio rename of the writer's vars/comments.
- Includes a JSON-parsing hardening fix from review.

Moving writer **and** reader together avoids a writer→RustFS / reader←MinIO split
brain.

## Out of scope (follow-ups)

- Cosmetic de-minio rename of install internals (`apps.yml` var names, the per-app
  marker file).
- `OBJECT_STORAGE_ROOT_USER/PASSWORD` must be added to Doppler `iac-conf-mgmt/prd`
  (values from the apps SOPS store) before the repoint converges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
