### PR TITLE
fix(ntp): scope remote_tmp to chrony validate task so site.yml deploys (#274)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,8 @@ holds no authoritative local inventory.
 ### External services
 
 - **Doppler**: Secrets for `SPLUNK_PASSWORD`, `HEC_NAMESPACE`,
-  `SPLUNK_HEC_TOKEN`, `SPLUNK_MCP_TOKEN`, `PROXMOX_SSH_KEY_PATH`.
+  `SPLUNK_HEC_TOKEN`, `SPLUNK_MCP_TOKEN`, `PROXMOX_SSH_KEY_PATH`,
+  `OBJECT_STORAGE_ROOT_USER`, `OBJECT_STORAGE_ROOT_PASSWORD`.
 
 ## Sources of truth
 
@@ -97,17 +98,17 @@ holds no authoritative local inventory.
 | `roles/splunk_docker/` | Splunk deployment role |
 | `roles/splunk_docker/files/` | App archives (gitignored) |
 | `playbooks/site.yml` | Full deployment playbook |
-| `playbooks/sync-splunkbase.yml` | MinIO sync for Splunkbase artifacts |
+| `playbooks/sync-splunkbase.yml` | Splunkbase → object-storage (RustFS) sync |
 | `playbooks/validate.yml` | Post-deploy validation |
 | `inventory/load_tofu.yml` | Dynamic inventory loader |
 
 ## Commands
 
 ```bash
-# Full deployment (MinIO → Splunk VM, direct target-side pull)
+# Full deployment (object storage → Splunk VM, direct target-side pull)
 doppler run -- ansible-playbook playbooks/site.yml
 
-# Sync Splunkbase → MinIO (run before site.yml when versions bumped)
+# Sync Splunkbase → object storage (run before site.yml when versions bumped)
 doppler run -- ansible-playbook playbooks/sync-splunkbase.yml
 
 # Validate deployment
@@ -142,16 +143,20 @@ ansible-lint
 2. Add entry to `roles/splunk_docker/vars/custom_addons.yml`.
 3. Re-run `doppler run -- ansible-playbook playbooks/site.yml`.
 
-## Artifact store (MinIO)
+## Artifact store (object-storage / RustFS)
 
-Custom add-ons that cannot be downloaded from Splunkbase or GitHub are
-served from a self-hosted MinIO instance (LXC container `minio`).
+Custom add-ons and resolved Splunkbase archives that the air-gapped Splunk
+VM pulls over the LAN are served from a self-hosted S3-compatible
+object-storage instance (RustFS LXC). Endpoint and port come from the
+OpenTofu inventory (`tofu_data.constants.service_ports.object_storage_s3`);
+bucket-write auth is `OBJECT_STORAGE_ROOT_USER` / `OBJECT_STORAGE_ROOT_PASSWORD`
+from Doppler.
 
 - Bucket: `splunk-addons` (anonymous read on internal network).
 - Add-ons with `artifact_store: true` in `vars/custom_addons.yml`
   auto-download.
 - Upload new versions via `mc cp` — filenames are version-free,
-  versions tracked via MinIO object tags.
+  versions tracked via object tags.
 - See `roles/splunk_docker/files/README.md` for upload instructions.
 
 ## MCP Server tools
@@ -201,7 +206,7 @@ rules to work around stale tooling.
 
 | Repo | Relationship |
 | --- | --- |
-| `dryvist/terraform-proxmox` | Upstream: provisions Splunk VM + MinIO LXC |
-| `dryvist/ansible-proxmox-apps` | Peer: owns Cribl (sends to HEC), deploys MinIO |
+| `dryvist/terraform-proxmox` | Upstream: provisions Splunk VM + object-storage (RustFS) LXC |
+| `dryvist/ansible-proxmox-apps` | Peer: owns Cribl (sends to HEC), deploys the object storage (RustFS) |
 | `dryvist/ansible-proxmox` | Peer: Proxmox host config |
 | `dryvist/nix-ai` | MCP client configuration (`modules/mcp/`) |

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,6 +4,10 @@ roles_path = roles
 host_key_checking = False
 retry_files_enabled = False
 gathering = smart
+# Stage temp files under /tmp, not $HOME. `template`/`copy` validate commands
+# (e.g. ntp role's `chronyd -p -f %s`) run under systemd ProtectHome=yes and
+# cannot read a rendered source file from /home/<user>/.ansible/tmp — see #274.
+remote_tmp = /tmp/.ansible-${USER}/tmp
 fact_caching = jsonfile
 fact_caching_connection = /tmp/ansible_facts
 fact_caching_timeout = 86400

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -4,10 +4,6 @@ roles_path = roles
 host_key_checking = False
 retry_files_enabled = False
 gathering = smart
-# Stage temp files under /tmp, not $HOME. `template`/`copy` validate commands
-# (e.g. ntp role's `chronyd -p -f %s`) run under systemd ProtectHome=yes and
-# cannot read a rendered source file from /home/<user>/.ansible/tmp — see #274.
-remote_tmp = /tmp/.ansible-${USER}/tmp
 fact_caching = jsonfile
 fact_caching_connection = /tmp/ansible_facts
 fact_caching_timeout = 86400

--- a/roles/ntp/tasks/main.yml
+++ b/roles/ntp/tasks/main.yml
@@ -20,6 +20,13 @@
     group: root
     mode: "0644"
     validate: chronyd -p -f %s
+  # Stage the validation source under /tmp, not the connection user's home.
+  # `validate: chronyd -p -f %s` runs under systemd ProtectHome=yes and cannot
+  # read /home/<user>/.ansible/tmp/...; staging in /tmp avoids it (#274). Ansible
+  # still creates a randomized 0700 `ansible-tmp-*` subdir here and cleans it up.
+  # Scoped to this task only — keep the secure home-dir default everywhere else.
+  vars:
+    ansible_remote_tmp: /tmp
   notify: Restart chrony
   tags:
     - ntp


### PR DESCRIPTION
## Summary

The ntp role's `Deploy chrony configuration` task validates with
`chronyd -p -f %s`. Under `become: true`, Ansible staged the rendered source
under the connection user's home (`/home/debian/.ansible/tmp/...`); `chronyd`
validates under systemd `ProtectHome=yes` and cannot read `/home`, so the task
failed with "Permission denied" and aborted `site.yml` **before Splunk — and
its app install — ever ran**. This is the likely original cause of the stale
Splunkbase apps that motivated the always-latest work (#272).

## Changes

- **`roles/ntp/tasks/main.yml`** — set `ansible_remote_tmp: /tmp` as a var on
  the chrony validate task only. `/tmp` is outside `ProtectHome`, and Ansible
  still creates a randomized `0700 ansible-tmp-*` subdir there and cleans it up.
  Scoped to the one task — the secure home-dir default stays everywhere else.
- **`AGENTS.md`** — repoint MinIO → object-storage (RustFS) to match the code
  after #276: artifact-store section, command comments, sources/peer tables,
  and the `OBJECT_STORAGE_ROOT_USER/PASSWORD` Doppler secrets.

A first pass set `remote_tmp` globally in `ansible.cfg`; review correctly
flagged controller-side `${USER}` expansion, global blast radius, and a
predictable `/tmp` path (CWE-377). Reverted in favor of the task-scoped var.

## Test Plan

- `ansible-lint --profile production` — 0 failures.
- `ansible-playbook playbooks/site.yml --syntax-check` — clean.
- CI: Ansible Lint, Molecule (default), Data Contract (Validate + Verify
  Inventory Load), Merge Gate — all pass.
- Live: `doppler run -- ansible-playbook playbooks/site.yml` (no `--skip-tags`)
  should now pass the NTP play and reach the Splunk deploy with `failed=0`.

Closes #274