### PR TITLE
docs: genericize Doppler config references in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Deploy and configure Splunk Enterprise (Docker) on a Proxmox VM.
 | **Target** | Splunk VM (VMID 200) — addressed from the tofu inventory, or DNS-first as `splunk-aio.{PROXMOX_DOMAIN}` |
 | **Role** | `roles/splunk_docker` |
 | **Entry point** | `playbooks/site.yml` |
-| **Secrets** | Doppler (`iac-conf-mgmt` / `prd`) |
+| **Secrets** | Doppler |
 | **Version** | See `VERSION` |
 
 ## Pipeline Architecture
@@ -128,7 +128,7 @@ Key defaults in `roles/splunk_docker/defaults/main.yml`:
 
 ## Secrets
 
-All secrets via Doppler (`iac-conf-mgmt` / `prd`):
+All secrets via your Doppler config:
 
 | Doppler Secret | Ansible Variable | Purpose |
 | --- | --- | --- |

--- a/roles/splunk_docker/README.md
+++ b/roles/splunk_docker/README.md
@@ -86,10 +86,10 @@ fallback that grants access to all indexes.
 
 ```bash
 # Generate a random namespace UUID (enables per-index tokens)
-doppler secrets set HEC_NAMESPACE "$(uuidgen)" -p iac-conf-mgmt -c prd
+doppler secrets set HEC_NAMESPACE "$(uuidgen)"
 
 # Set the shared legacy token (always required)
-doppler secrets set SPLUNK_HEC_TOKEN "$(uuidgen)" -p iac-conf-mgmt -c prd
+doppler secrets set SPLUNK_HEC_TOKEN "$(uuidgen)"
 ```
 
 ### Adding a New Index + Token


### PR DESCRIPTION
## Summary

Removes the specific Doppler project/config name from public-facing documentation. The exact vault is an implementation detail and does not belong in a public repo's docs. References are now generic ("Doppler" / "your Doppler config") while all setup instructions and individual secret KEY names (`SPLUNK_*`, `HEC_NAMESPACE`, etc.) are preserved.

## Changes

- `README.md` — Quick Facts secrets row and the Secrets section intro no longer name the specific project/config.
- `roles/splunk_docker/README.md` — `doppler secrets set ...` examples drop the explicit `-p ... -c ...` project/config flags; they now rely on the active Doppler config (set once via `doppler setup`).

Meaning is preserved: `doppler secrets set` / `doppler run` operate against the configured Doppler context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019whZYTbrt4DnoyXVE5gCF9