### PR TITLE
fix(splunk): auto-reconcile admin password with SPLUNK_PASSWORD

### DIFF
--- a/roles/splunk_docker/tasks/main.yml
+++ b/roles/splunk_docker/tasks/main.yml
@@ -182,6 +182,13 @@
     | selectattr('status', 'in', ['Creating', 'Recreating', 'Pulling', 'Building'])
     | list | length > 0
 
+# Self-heal the admin-password drift trap (stale persisted passwd vs rotated
+# SPLUNK_PASSWORD) BEFORE the readiness wait — otherwise a 401 restart-loop
+# would just time the wait out. No-op when the password is already in sync.
+- name: Reconcile admin password with SPLUNK_PASSWORD
+  ansible.builtin.include_tasks: reconcile_admin_password.yml
+  when: splunk_docker_wait_enabled
+
 - name: Wait for Splunk to be ready
   ansible.builtin.include_tasks: wait_for_splunk.yml
 

--- a/roles/splunk_docker/tasks/reconcile_admin_password.yml
+++ b/roles/splunk_docker/tasks/reconcile_admin_password.yml
@@ -1,0 +1,77 @@
+---
+# Keep the live container admin password in sync with SPLUNK_PASSWORD (Doppler).
+#
+# The splunk/splunk image seeds admin from SPLUNK_PASSWORD ONLY on first boot,
+# when etc/passwd is absent. etc/ is a persistent bind mount, so a later Doppler
+# rotation leaves the running container on the OLD password and splunk-ansible
+# 401s on its own REST API forever ("Get existing HEC token"). This reconciles
+# that drift automatically via the official password-reset path — no manual
+# `qm guest exec` (see terraform-proxmox TROUBLESHOOTING.md "Splunk Container").
+#
+# ponytail: Doppler is the single source of truth and wins — a password changed
+# directly in the Splunk UI is overwritten on the next converge. If per-user UI
+# password management is ever wanted, gate this behind a flag then.
+
+- name: Check whether a persisted admin passwd exists
+  ansible.builtin.stat:
+    path: "{{ splunk_docker_etc_dir }}/passwd"
+  register: splunk_docker_passwd_file
+
+# Probe the REST API with the CURRENT password. 200 = in sync (no-op below);
+# 401 = the persisted passwd has drifted from SPLUNK_PASSWORD. `until` rides out
+# the restart-loop windows where splunkd is briefly down (status -1); failed_when
+# false so a never-ready splunkd falls through to wait_for_splunk's louder error.
+- name: Probe admin auth against the Splunk REST API
+  ansible.builtin.uri:
+    url: "https://127.0.0.1:{{ splunk_docker_mgmt_port }}/services/server/info"
+    user: admin
+    password: "{{ splunk_docker_password }}"
+    force_basic_auth: true
+    validate_certs: false
+    status_code: [200, 401]
+  register: splunk_docker_pw_probe
+  until: (splunk_docker_pw_probe.status | default(-1) | int) in [200, 401]
+  retries: 30
+  delay: 10
+  failed_when: false
+  no_log: true
+  when: splunk_docker_passwd_file.stat.exists
+
+- name: Reseed admin password from SPLUNK_PASSWORD (drift detected)
+  when: (splunk_docker_pw_probe.status | default(0) | int) == 401
+  block:
+    - name: Stop Splunk before reseeding admin
+      community.docker.docker_compose_v2:
+        project_src: "{{ splunk_docker_config_dir }}"
+        state: stopped
+
+    - name: Back up the stale passwd file
+      ansible.builtin.copy:
+        src: "{{ splunk_docker_etc_dir }}/passwd"
+        dest: "{{ splunk_docker_etc_dir }}/passwd.stale"
+        remote_src: true
+        mode: preserve
+
+    # Removing passwd makes the image treat next boot as un-seeded, so it
+    # consumes user-seed.conf and recreates admin = SPLUNK_PASSWORD.
+    - name: Remove the stale passwd file
+      ansible.builtin.file:
+        path: "{{ splunk_docker_etc_dir }}/passwd"
+        state: absent
+
+    - name: Write user-seed.conf with the current SPLUNK_PASSWORD
+      ansible.builtin.copy:
+        content: |
+          [user_info]
+          USERNAME = admin
+          PASSWORD = {{ splunk_docker_password }}
+        dest: "{{ splunk_docker_etc_dir }}/system/local/user-seed.conf"
+        owner: "{{ splunk_docker_user }}"
+        group: "{{ splunk_docker_group }}"
+        mode: '0600'
+      no_log: true
+
+    - name: Start Splunk so it reseeds admin from user-seed.conf
+      community.docker.docker_compose_v2:
+        project_src: "{{ splunk_docker_config_dir }}"
+        state: present


### PR DESCRIPTION
## Problem

The `splunk/splunk` image seeds the admin password from `SPLUNK_PASSWORD`
**only on first boot** (when `etc/passwd` is absent). `etc/` is a persistent
bind mount, so a later password rotation leaves the running container on the
**old** password — splunk-ansible then 401-loops on its own REST API forever
(`Get existing HEC token`), and admin auth (REST + UI) fails for every client.

Recovery was a manual host-side procedure; the password was never kept in sync
with the secret store automatically.

## Fix

Add an idempotent `reconcile_admin_password.yml`, included after the container
starts and before the readiness wait:

- Probe the REST API (`/services/server/info`) with the current password.
- `200` → already in sync → no-op (a healthy container is never restarted).
- `401` → drift → official reset: stop, back up + remove the stale `passwd`,
  write `user-seed.conf` with the current password, start. The image recreates
  admin from `SPLUNK_PASSWORD` on the next boot.

The secret store is the single source of truth and wins; a password changed
directly in the Splunk UI is overwritten on the next converge (noted inline).

## Verification

- `ansible-lint` passes (production profile).
- `ansible-playbook playbooks/site.yml --syntax-check` passes.
- Live: re-converge on a drifted container resets it once; a second converge
  reports `changed=0` for the reconcile (idempotent); REST auth returns `200`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)