### PR TITLE
feat(alerts): per-host LLM silence + LiteLLM router and model-eval alerts

### DIFF
--- a/roles/splunk_docker/templates/savedsearches.conf.j2
+++ b/roles/splunk_docker/templates/savedsearches.conf.j2
@@ -47,6 +47,9 @@ disabled = 0
 alert.severity = 3
 alert.suppress = 1
 alert.suppress.period = 120m
+# Scope suppression per host: without this, the first silent host suppresses
+# the alert globally and a second host failing inside the window goes unseen.
+alert.suppress.fields = host
 alert.track = 1
 counttype = number of events
 relation = greater than
@@ -96,7 +99,10 @@ action.email.message.alert = A model-server manager panic reached the llm index.
 --------------------------------------------------------------------------- #}
 [llm_router_silence_detector]
 description = Alerts when the LiteLLM router stops recording requests in index=ai for more than 15 minutes. The router is the single endpoint every LLM consumer resolves, so its silence means the whole fabric is unreachable even if individual model servers are healthy. Assumes router request events land as index=ai sourcetype=litellm (see comment above).
-search = | tstats latest(_time) as last_seen WHERE index=ai sourcetype=litellm | eval minutes_silent = (now() - last_seen) / 60 | where minutes_silent > 15
+# coalesce: with zero events in the whole lookback window, tstats yields a
+# null last_seen; without the fallback the where clause filters the row out
+# and the alert goes quiet exactly when the router has been dead longest.
+search = | tstats latest(_time) as last_seen WHERE index=ai sourcetype=litellm | eval minutes_silent = (now() - coalesce(last_seen, 0)) / 60 | where minutes_silent > 15
 dispatch.earliest_time = -24h
 dispatch.latest_time = now
 cron_schedule = */5 * * * *
@@ -162,6 +168,9 @@ disabled = 0
 alert.severity = 3
 alert.suppress = 1
 alert.suppress.period = 6h
+# Models/suites are independent: scope suppression so one regression cannot
+# mask another model+suite regressing inside the window.
+alert.suppress.fields = model,suite
 alert.track = 1
 counttype = number of events
 relation = greater than

--- a/roles/splunk_docker/templates/savedsearches.conf.j2
+++ b/roles/splunk_docker/templates/savedsearches.conf.j2
@@ -36,8 +36,8 @@ action.email.message.alert = The macbook-m4 Cribl Edge pipeline has not delivere
 {% endif %}
 
 [llm_pipeline_silence_detector]
-description = Alerts when the llm index (local LLM-stack telemetry via Cribl Edge -> HAProxy -> Cribl Stream) has been silent for more than 30 minutes while expected to flow.
-search = | tstats latest(_time) as last_seen WHERE index=llm | eval minutes_silent = (now() - last_seen) / 60 | where minutes_silent > 30
+description = Alerts when any llama-swap emitter feeding the llm index goes silent for more than 30 minutes. Detection is PER-HOST (`by host`) so a healthy emitter can never mask a dead one — with the fabric running multiple llama-swap serving guests, an index-wide `latest(_time)` would stay fresh as long as a single host reports, hiding the failure of every other host. Each silent host produces its own result row, so the alert fires once per dead emitter. A host that has never emitted has no baseline and cannot be detected here (same inherent limitation as the macOS edge detector).
+search = | tstats latest(_time) as last_seen WHERE index=llm by host | eval minutes_silent = (now() - last_seen) / 60 | where minutes_silent > 30
 dispatch.earliest_time = -24h
 dispatch.latest_time = now
 cron_schedule = */10 * * * *
@@ -54,8 +54,8 @@ quantity = 0
 {% if splunk_docker_alert_email %}
 action.email = 1
 action.email.to = {{ splunk_docker_alert_email }}
-action.email.subject = [Splunk Alert] llm index silent
-action.email.message.alert = The llm index has received no events for 30+ minutes. Investigate the Mac Cribl Edge daemon, HAProxy :10300 frontend, Cribl Stream input, and Splunk HEC ingestion.
+action.email.subject = [Splunk Alert] llm emitter silent (per-host)
+action.email.message.alert = One or more llama-swap emitters feeding the llm index have delivered no events for 30+ minutes (see the `host` field in the results for which). Investigate that host's llama-swap serving guest, its Cribl Edge daemon, the HAProxy :10300 frontend, the Cribl Stream input, and Splunk HEC ingestion.
 {% endif %}
 
 [llm_manager_panic_detector]
@@ -79,4 +79,96 @@ action.email = 1
 action.email.to = {{ splunk_docker_alert_email }}
 action.email.subject = [Splunk Alert] LLM manager panic detected
 action.email.message.alert = A model-server manager panic reached the llm index. Workers may be unmanaged; check the inference stack and consider a manager restart.
+{% endif %}
+
+{# ---------------------------------------------------------------------------
+   LiteLLM router alerts.
+
+   The LLM fabric fronts every model consumer with a LiteLLM router (multiple
+   instances behind a single virtual endpoint). Router request telemetry flows
+   app -> OTLP -> Cribl -> Splunk into index=ai. This template stamps that
+   traffic with sourcetype=litellm — mirroring the index=llm / sourcetype=
+   llamaswap convention used above (service-named sourcetype). This is the one
+   load-bearing assumption in the router searches: the Cribl pipeline (or the
+   router's own log/OTLP metadata) MUST land these events as
+   `index=ai sourcetype=litellm`. If the fabric stamps a different sourcetype,
+   update `litellm` in both searches below to match — nothing else changes.
+--------------------------------------------------------------------------- #}
+[llm_router_silence_detector]
+description = Alerts when the LiteLLM router stops recording requests in index=ai for more than 15 minutes. The router is the single endpoint every LLM consumer resolves, so its silence means the whole fabric is unreachable even if individual model servers are healthy. Assumes router request events land as index=ai sourcetype=litellm (see comment above).
+search = | tstats latest(_time) as last_seen WHERE index=ai sourcetype=litellm | eval minutes_silent = (now() - last_seen) / 60 | where minutes_silent > 15
+dispatch.earliest_time = -24h
+dispatch.latest_time = now
+cron_schedule = */5 * * * *
+enableSched = 1
+is_visible = 1
+disabled = 0
+alert.severity = 4
+alert.suppress = 1
+alert.suppress.period = 60m
+alert.track = 1
+counttype = number of events
+relation = greater than
+quantity = 0
+{% if splunk_docker_alert_email %}
+action.email = 1
+action.email.to = {{ splunk_docker_alert_email }}
+action.email.subject = [Splunk Alert] LiteLLM router silent
+action.email.message.alert = The LiteLLM router has recorded no requests in index=ai for 15+ minutes. Every LLM consumer resolves this single endpoint, so the fabric is likely unreachable. Investigate the router instances, their OTLP exporter, the Cribl pipeline into index=ai, and Splunk HEC ingestion.
+{% endif %}
+
+[llm_router_fallback_spike]
+description = Alerts when the LiteLLM router logs a spike of fallback/cooldown/5xx events in index=ai over a 15-minute window — a healthy router serves almost entirely from its primary targets, so a burst of fallbacks or upstream 5xx/cooldown events means one or more backend model servers are failing or overloaded. Assumes router events land as index=ai sourcetype=litellm (see comment above). Threshold is a count over the dispatch window; tune it to the fabric's request volume.
+search = index=ai sourcetype=litellm ("fallback" OR "cooldown" OR "cooling down" OR status_code>=500) | stats count | where count > 20
+dispatch.earliest_time = -15m
+dispatch.latest_time = now
+cron_schedule = */5 * * * *
+enableSched = 1
+is_visible = 1
+disabled = 0
+alert.severity = 4
+alert.suppress = 1
+alert.suppress.period = 30m
+alert.track = 1
+counttype = number of events
+relation = greater than
+quantity = 0
+{% if splunk_docker_alert_email %}
+action.email = 1
+action.email.to = {{ splunk_docker_alert_email }}
+action.email.subject = [Splunk Alert] LiteLLM router fallback/error spike
+action.email.message.alert = The LiteLLM router logged more than 20 fallback / cooldown / 5xx events in the last 15 minutes. A backend model server is likely failing or overloaded and the router is shedding load onto its fallbacks. Check the router logs and the health of each backend target.
+{% endif %}
+
+{# ---------------------------------------------------------------------------
+   Model-eval regression.
+
+   promptfoo eval suites publish per-model/per-suite scores into index=ai as
+   sourcetype=model_eval (HEC events carry their own sourcetype, so no props/
+   transforms entry is needed in this role — the index=ai index already exists).
+   This search compares each model+suite's newest score against its previous
+   score and fires when a run regresses beyond the tolerance. Kept simple: it
+   assumes each event carries `model`, `suite`, and a numeric `score` field.
+--------------------------------------------------------------------------- #}
+[model_eval_regression]
+description = Alerts when a promptfoo model-eval run regresses: the latest score for a model+suite drops more than 0.05 below the previous run's score. Reads index=ai sourcetype=model_eval events (fields: model, suite, score). Catches quality regressions from a model swap or routing-policy change before they reach consumers.
+search = index=ai sourcetype=model_eval | sort 0 model suite -_time | streamstats count as run_rank by model suite | where run_rank <= 2 | stats first(score) as latest_score last(score) as prev_score by model suite | where (prev_score - latest_score) > 0.05 | table model suite latest_score prev_score
+dispatch.earliest_time = -7d
+dispatch.latest_time = now
+cron_schedule = 15 * * * *
+enableSched = 1
+is_visible = 1
+disabled = 0
+alert.severity = 3
+alert.suppress = 1
+alert.suppress.period = 6h
+alert.track = 1
+counttype = number of events
+relation = greater than
+quantity = 0
+{% if splunk_docker_alert_email %}
+action.email = 1
+action.email.to = {{ splunk_docker_alert_email }}
+action.email.subject = [Splunk Alert] Model-eval score regression
+action.email.message.alert = A promptfoo eval suite regressed: the latest score for a model+suite fell more than 0.05 below the prior run (see the model / suite / score / prev_score fields). Review the recent model or routing-policy change that preceded the drop.
 {% endif %}


### PR DESCRIPTION
## What

Reworks the LLM-fabric saved searches in `roles/splunk_docker/templates/savedsearches.conf.j2` for the new multi-emitter LLM fabric (LiteLLM router + multiple llama-swap serving guests).

### Changes

1. **`llm_pipeline_silence_detector` — now per-host.** Switched to `| tstats latest(_time) ... by host`. With the fabric running multiple llama-swap emitters into `index=llm`, an index-wide `latest(_time)` stays fresh as long as *any* one host reports, silently masking the death of every other emitter. Per-host detection yields one result row per silent host.
2. **`llm_router_silence_detector` (new).** Fires when the LiteLLM router records no requests in `index=ai` for 15+ minutes. The router is the single endpoint every LLM consumer resolves, so its silence means the fabric is unreachable even when individual model servers are healthy.
3. **`llm_router_fallback_spike` (new).** Fires on a burst of fallback / cooldown / 5xx events over a 15-minute window — a healthy router serves almost entirely from primary targets, so a spike signals a failing or overloaded backend.
4. **`model_eval_regression` (new).** Compares each model+suite's latest promptfoo score against the prior run and fires on a >0.05 regression.

### Sourcetype assumption (load-bearing)

Router and eval telemetry are assumed to land as `index=ai sourcetype=litellm` and `index=ai sourcetype=model_eval` respectively — mirroring the existing `index=llm sourcetype=llamaswap` service-named convention. HEC events carry their own sourcetype, so **no props/transforms entry is needed** (and `index=ai` already exists in `defaults/main.yml`). The assumption is documented inline; if the Cribl pipeline stamps a different sourcetype, only the `litellm` token in the two router searches needs updating.

## Test

- Existing stanza style preserved exactly (cron, dispatch, alert actions, email guard).
- Jinja `{% if %}`/`{% endif %}` and `{# #}` comment blocks balanced; all six stanzas parse.
- Repo CI (CI Gate: lint + Molecule) + data-contract checks to run on PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj