### PR TITLE
fix(playbooks): align Splunk guest network with tofu inventory via guest agent

### DIFF
--- a/playbooks/align_guest_network.yml
+++ b/playbooks/align_guest_network.yml
@@ -52,6 +52,11 @@
         qm guest exec {{ splunk_guest.vmid }} -- ip -4 -o addr show eth0
       delegate_to: splunk-pve-node
       register: guest_addr
+      # qm guest exec exits 0 on the host even when the in-guest command
+      # fails; the real status is the exitcode field of its JSON output.
+      failed_when: >-
+        guest_addr.rc != 0
+        or (guest_addr.stdout | from_json).exitcode != 0
       changed_when: false
 
     - name: Write the netplan overlay and apply it in the guest
@@ -70,9 +75,15 @@
             > /etc/netplan/60-tofu-address.yaml &&
             netplan apply && echo NETPLAN_OK
       delegate_to: splunk-pve-node
-      when: (splunk_guest.ip ~ '/') not in guest_addr.stdout
+      when: >-
+        (splunk_guest.ip ~ '/')
+        not in (guest_addr.stdout | from_json).get('out-data', '')
       register: netplan_write
-      failed_when: "'NETPLAN_OK' not in netplan_write.stdout"
+      failed_when: >-
+        netplan_write.rc != 0
+        or (netplan_write.stdout | from_json).exitcode != 0
+        or 'NETPLAN_OK' not in
+           (netplan_write.stdout | from_json).get('out-data', '')
       changed_when: true
 
     - name: Wait for SSH on the declared address

--- a/playbooks/align_guest_network.yml
+++ b/playbooks/align_guest_network.yml
@@ -1,0 +1,82 @@
+---
+# Align the Splunk VM's in-guest address with the tofu-declared one.
+#
+# OpenTofu manages only the NIC VLAN tag on this VM (initialization ip_config
+# is in ignore_changes) and cloud-init renders guest networking at first boot
+# only, so a VLAN renumber leaves the guest dark on its old subnet — and
+# unreachable over SSH, which rules out the normal converge path. This
+# playbook closes that gap from the Proxmox node that hosts the VM, through
+# the QEMU guest agent: it writes a netplan overlay for the inventory-derived
+# address and applies it. Nameservers still merge in from the first-boot
+# 50-cloud-init.yaml, which the overlay deliberately does not touch.
+#
+# Idempotent: a guest already holding the declared address is left untouched.
+#
+# Usage (same wrapper as the other playbooks):
+#   doppler run -- ansible-playbook -i inventory/hosts.yml \
+#     playbooks/align_guest_network.yml --diff
+
+- name: Load OpenTofu inventory
+  ansible.builtin.import_playbook: ../inventory/load_tofu.yml
+
+- name: Align Splunk guest network via the QEMU guest agent
+  hosts: localhost
+  gather_facts: false
+  vars:
+    splunk_guest: "{{ tofu_data.splunk_vm.splunk }}"
+    # The homelab convention everywhere: the gateway is .1 of the guest's /24.
+    guest_gateway: "{{ (splunk_guest.ip.split('.'))[0:3] | join('.') }}.1"
+    netplan_overlay: |
+      # Managed by ansible-splunk (playbooks/align_guest_network.yml).
+      # Overrides the first-boot 50-cloud-init.yaml address after VLAN
+      # renumbers; nameservers still merge in from the cloud-init file.
+      network:
+        version: 2
+        ethernets:
+          eth0:
+            addresses:
+              - {{ splunk_guest.ip }}/24
+            gateway4: {{ guest_gateway }}
+  tasks:
+    - name: Register the Proxmox node hosting the Splunk VM
+      ansible.builtin.add_host:
+        name: splunk-pve-node
+        ansible_host: "{{ splunk_guest.node }}.{{ tofu_data.domain }}"
+        ansible_user: root
+        ansible_ssh_private_key_file: "{{ lookup('env', 'PROXMOX_SSH_KEY_PATH') | mandatory }}"
+        ansible_python_interpreter: /usr/bin/python3
+      changed_when: false
+
+    - name: Read the guest's current eth0 address
+      ansible.builtin.command: >-
+        qm guest exec {{ splunk_guest.vmid }} -- ip -4 -o addr show eth0
+      delegate_to: splunk-pve-node
+      register: guest_addr
+      changed_when: false
+
+    - name: Write the netplan overlay and apply it in the guest
+      ansible.builtin.command:
+        argv:
+          - qm
+          - guest
+          - exec
+          - "{{ splunk_guest.vmid }}"
+          - --
+          - sh
+          - -c
+          - >-
+            umask 077 &&
+            echo '{{ netplan_overlay | b64encode }}' | base64 -d
+            > /etc/netplan/60-tofu-address.yaml &&
+            netplan apply && echo NETPLAN_OK
+      delegate_to: splunk-pve-node
+      when: (splunk_guest.ip ~ '/') not in guest_addr.stdout
+      register: netplan_write
+      failed_when: "'NETPLAN_OK' not in netplan_write.stdout"
+      changed_when: true
+
+    - name: Wait for SSH on the declared address
+      ansible.builtin.wait_for:
+        host: "{{ splunk_guest.ip }}"
+        port: 22
+        timeout: 120


### PR DESCRIPTION
## Why

A VLAN renumber retags the Splunk VM's NIC (tofu-managed) but the guest OS keeps its first-boot cloud-init address: tofu deliberately ignores `initialization[0].ip_config` and no role owns guest networking, so the VM goes dark on the new VLAN and the normal SSH converge path cannot reach it.

## What

New `playbooks/align_guest_network.yml`:
- loads the tofu inventory (declared ip / vmid / node / domain — nothing hardcoded)
- reaches the guest from its Proxmox node via `qm guest exec` (QEMU guest agent works regardless of guest network state)
- writes a netplan overlay (`60-tofu-address.yaml`) with the declared address + derived gateway, leaving nameservers to merge from the first-boot `50-cloud-init.yaml`
- `netplan apply`, then waits for SSH on the declared address
- idempotent: no-op when the guest already holds the declared address

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SLpU9zVuAPzC8aJLGAKhdj