### PR TITLE
feat(splunk): add Splunkbase 8278 registry entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
-* **splunk:** repoint Splunkbase sync MinIO → object-storage (RustFS) ([#276](https://github.com/dryvist/ansible-splunk/issues/276)) ([b318baa](https://github.com/dryvist/ansible-splunk/commit/b318baa86045852065eade5c9bb823ad0d6616a0))
+* **splunk:** repoint Splunkbase sync to object-storage (RustFS) ([#276](https://github.com/dryvist/ansible-splunk/issues/276)) ([b318baa](https://github.com/dryvist/ansible-splunk/commit/b318baa86045852065eade5c9bb823ad0d6616a0))
 
 ## [0.22.0](https://github.com/dryvist/ansible-splunk/compare/v0.21.0...v0.22.0) (2026-06-20)
 
@@ -314,14 +314,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-* **splunk:** MinIO add-on registry + Splunkbase auto-sync ([7364448](https://github.com/JacobPEvans/ansible-splunk/commit/736444891f658d374e85329b5fecb47cc5612a9d))
+* **splunk:** object-storage add-on registry + Splunkbase auto-sync ([7364448](https://github.com/JacobPEvans/ansible-splunk/commit/736444891f658d374e85329b5fecb47cc5612a9d))
 
 ## [0.9.0](https://github.com/JacobPEvans/ansible-splunk/compare/v0.8.1...v0.9.0) (2026-04-09)
 
 ### Features
 
-* add MinIO artifact store + propagate terraform_data to all hosts ([#124](https://github.com/JacobPEvans/ansible-splunk/issues/124)) ([804eb55](https://github.com/JacobPEvans/ansible-splunk/commit/804eb55dc49aeea7561db51375c5c9efae4f6d6e))
-* add MinIO artifact store for custom add-on downloads ([#118](https://github.com/JacobPEvans/ansible-splunk/issues/118)) ([20a1efe](https://github.com/JacobPEvans/ansible-splunk/commit/20a1efeae4e451eb8fc132a460a1883ca42b8d12))
+* add object-storage artifact store + propagate terraform_data to all hosts ([#124](https://github.com/JacobPEvans/ansible-splunk/issues/124)) ([804eb55](https://github.com/JacobPEvans/ansible-splunk/commit/804eb55dc49aeea7561db51375c5c9efae4f6d6e))
+* add object-storage artifact store for custom add-on downloads ([#118](https://github.com/JacobPEvans/ansible-splunk/issues/118)) ([20a1efe](https://github.com/JacobPEvans/ansible-splunk/commit/20a1efeae4e451eb8fc132a460a1883ca42b8d12))
 
 ## [0.8.1](https://github.com/JacobPEvans/ansible-splunk/compare/v0.8.0...v0.8.1) (2026-04-07)
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -35,7 +35,7 @@ provisioner:
       all:
         # Test values for molecule - override in production
         splunk_docker_password: "molecule-test-password"
-        # Empty the add-on registry so molecule never tries to reach MinIO
+        # Empty the add-on registry so molecule never tries to reach object storage
         # or GitHub at converge time. apps.yml loops over splunk_docker_addons;
         # an empty list is a no-op.
         splunk_docker_addons: []

--- a/roles/splunk_docker/files/README.md
+++ b/roles/splunk_docker/files/README.md
@@ -1,7 +1,7 @@
 # Splunk App Files (gitignored, runtime-only)
 
 This directory is gitignored. The `splunk_docker` role does **not** stage
-archives here — every add-on is pulled by the Splunk VM directly from MinIO
+archives here — every add-on is pulled by the Splunk VM directly from object storage
 (or GitHub Releases) via `ansible.builtin.unarchive` with `remote_src: true`.
 
 ## Installation
@@ -15,7 +15,7 @@ doppler run -- ansible-playbook playbooks/site.yml
 
 The role reads `../vars/addons.yml` and, for each entry, issues an
 `ansible.builtin.unarchive` against the target Splunk VM. The VM downloads
-the archive directly from MinIO (or GitHub) and extracts it into
+the archive directly from object storage (or GitHub) and extracts it into
 `/opt/splunk/etc/apps/`. The `creates:` guard skips any app whose target
 directory already exists.
 
@@ -25,9 +25,9 @@ directory already exists.
 
 Every installed add-on is listed in `../vars/addons.yml`. Each entry has:
 
-- `filename` — archive name in the MinIO `splunk-addons` bucket or GitHub release asset
+- `filename` — archive name in the object-storage `splunk-addons` bucket or GitHub release asset
 - `app_dir` — extracted directory name under `/opt/splunk/etc/apps/` (used by `creates:` for idempotency and by `validate.yml` to assert installation)
-- `github_repo` — optional. If set, download from `github.com/<repo>/releases/latest`; otherwise download from MinIO.
+- `github_repo` — optional. If set, download from `github.com/<repo>/releases/latest`; otherwise download from object storage.
 
 ### Adding / rotating an add-on
 
@@ -39,7 +39,7 @@ mc cp ~/Downloads/splunk-db-connect_425.tar homelab/splunk-addons/splunk-db-conn
 mc tag set homelab/splunk-addons/splunk-db-connect.tar "version=4.2.5"
 
 # If this is a new add-on, also add an entry to vars/addons.yml.
-# Nothing else. The Splunk VM pulls from MinIO on the next playbook run.
+# Nothing else. The Splunk VM pulls from object storage on the next playbook run.
 ```
 
 To force re-extraction after rotating a file with the same name, delete the

--- a/roles/splunk_docker/tasks/apps.yml
+++ b/roles/splunk_docker/tasks/apps.yml
@@ -2,15 +2,15 @@
 # App installation tasks — installs/upgrades every entry in splunk_docker_addons.
 #
 # Target-side direct pull: the air-gapped Splunk VM downloads each archive straight
-# from MinIO (or GitHub releases) via `ansible.builtin.unarchive` with
-# `remote_src: true`. The Ansible controller never stages archives — MinIO is the
-# single source of truth.
+# from object storage (or GitHub releases) via `ansible.builtin.unarchive` with
+# `remote_src: true`. The Ansible controller never stages archives — object storage
+# is the single source of truth.
 #
-# VERSION-AWARE (no install-once): MinIO-sourced apps are (re)extracted whenever the
+# VERSION-AWARE (no install-once): object-storage-sourced apps are (re)extracted whenever the
 # version differs from what's installed, not merely when the dir is absent. The
 # desired version comes from `manifest.json` (published by sync-splunkbase.yml,
 # app_dir → {version, filename}); the installed version is recorded in a
-# `.minio_version` marker we write inside each app dir. This is what makes
+# `.object_storage_version` marker we write inside each app dir. This is what makes
 # "always updated to the latest" actually hold — the old `creates:` guard froze
 # every app at its first-installed version forever.
 #
@@ -30,63 +30,63 @@
     group: "{{ splunk_docker_group }}"
     mode: '0755'
 
-# --- MinIO-sourced apps: version-aware install/upgrade ---
+# --- object-storage-sourced apps: version-aware install/upgrade ---
 
-- name: Build the MinIO-sourced add-on list
+- name: Build the object-storage-sourced add-on list
   ansible.builtin.set_fact:
-    splunk_docker_minio_addons: "{{ splunk_docker_addons | rejectattr('github_repo', 'defined') | list }}"
+    splunk_docker_object_storage_addons: "{{ splunk_docker_addons | rejectattr('github_repo', 'defined') | list }}"
 
 # Gated on a non-empty list so Molecule (which sets splunk_docker_addons: []) never
 # templates splunk_docker_artifact_base_url / tofu_data, which it does not provide.
-- name: Fetch the MinIO add-on version manifest
+- name: Fetch the object-storage add-on version manifest
   ansible.builtin.uri:
     url: "{{ splunk_docker_artifact_base_url }}/manifest.json"
     method: GET
     return_content: true
     status_code: [200, 403, 404]
-  register: splunk_docker_minio_manifest_q
+  register: splunk_docker_object_storage_manifest_q
   changed_when: false
   failed_when: false
-  when: splunk_docker_minio_addons | length > 0
+  when: splunk_docker_object_storage_addons | length > 0
 
-# Empty when the manifest is absent/skipped (no sync has run yet, or no MinIO apps)
-# — every MinIO app then falls back to install-if-missing, like the legacy behaviour.
+# Empty when the manifest is absent/skipped (no sync has run yet, or no object-storage apps)
+# — every object-storage app then falls back to install-if-missing, like the legacy behaviour.
 - name: Parse the version manifest (empty when absent/unreadable)
   ansible.builtin.set_fact:
-    splunk_docker_minio_manifest: >-
-      {{ (splunk_docker_minio_manifest_q.content | from_json)
-         if (splunk_docker_minio_manifest_q.status | default(0)) == 200
-            and (splunk_docker_minio_manifest_q.content | default('') | trim)[:1] == '{'
+    splunk_docker_object_storage_manifest: >-
+      {{ (splunk_docker_object_storage_manifest_q.content | from_json)
+         if (splunk_docker_object_storage_manifest_q.status | default(0)) == 200
+            and (splunk_docker_object_storage_manifest_q.content | default('') | trim)[:1] == '{'
          else {} }}
 
 - name: Read installed version markers
   ansible.builtin.slurp:
-    src: "{{ splunk_docker_etc_dir }}/apps/{{ item.app_dir }}/.minio_version"
-  register: splunk_docker_minio_markers
-  loop: "{{ splunk_docker_minio_addons }}"
+    src: "{{ splunk_docker_etc_dir }}/apps/{{ item.app_dir }}/.object_storage_version"
+  register: splunk_docker_object_storage_markers
+  loop: "{{ splunk_docker_object_storage_addons }}"
   loop_control:
     label: "{{ item.app_dir }}"
   failed_when: false  # missing marker → not installed (or legacy install)
 
 # Initialise accumulators so they stay defined when the loop is empty (Molecule).
-- name: Initialise MinIO install accumulators
+- name: Initialise object-storage install accumulators
   ansible.builtin.set_fact:
-    splunk_docker_minio_plan: []
-    splunk_docker_minio_decided: []
+    splunk_docker_object_storage_plan: []
+    splunk_docker_object_storage_decided: []
 
 # needs_install when:
 #   manifest app (desired != ''): installed version differs from desired
 #   manual  app (desired == ''):  not yet installed
 - name: Compute install/upgrade decisions
   ansible.builtin.set_fact:
-    splunk_docker_minio_plan: >-
-      {{ splunk_docker_minio_plan | default([]) + [item.0 | combine({
-        'desired_version': ((splunk_docker_minio_manifest[item.0.app_dir] | default({})).version | default('')),
+    splunk_docker_object_storage_plan: >-
+      {{ splunk_docker_object_storage_plan | default([]) + [item.0 | combine({
+        'desired_version': ((splunk_docker_object_storage_manifest[item.0.app_dir] | default({})).version | default('')),
         'installed_version': (
           (item.1.content | b64decode | trim) if item.1.content is defined else ''
         ),
       })] }}
-  loop: "{{ splunk_docker_minio_addons | zip(splunk_docker_minio_markers.results) | list }}"
+  loop: "{{ splunk_docker_object_storage_addons | zip(splunk_docker_object_storage_markers.results) | list }}"
   loop_control:
     label: "{{ item.0.app_dir }}"
 
@@ -94,14 +94,14 @@
 # computed per-item into a bool flag here.
 - name: Mark each app's install need
   ansible.builtin.set_fact:
-    splunk_docker_minio_decided: >-
-      {{ splunk_docker_minio_decided | default([]) + [item | combine({
+    splunk_docker_object_storage_decided: >-
+      {{ splunk_docker_object_storage_decided | default([]) + [item | combine({
         '_needs_install': (
           (item.desired_version != '' and item.desired_version != item.installed_version)
           or (item.desired_version == '' and item.installed_version == '')
         )
       })] }}
-  loop: "{{ splunk_docker_minio_plan }}"
+  loop: "{{ splunk_docker_object_storage_plan }}"
   loop_control:
     label: "{{ item.app_dir }}"
 
@@ -111,7 +111,7 @@
       {{ item.app_dir }}: desired={{ item.desired_version or '(manual)' }}
       installed={{ item.installed_version or '(none)' }}
       → {{ 'INSTALL' if item._needs_install else 'skip' }}
-  loop: "{{ splunk_docker_minio_decided }}"
+  loop: "{{ splunk_docker_object_storage_decided }}"
   loop_control:
     label: "{{ item.app_dir }}"
 
@@ -121,18 +121,18 @@
   ansible.builtin.file:
     path: "{{ splunk_docker_etc_dir }}/apps/{{ item.app_dir }}"
     state: absent
-  loop: "{{ splunk_docker_minio_decided | selectattr('_needs_install') | selectattr('installed_version', 'ne', '') | list }}"
+  loop: "{{ splunk_docker_object_storage_decided | selectattr('_needs_install') | selectattr('installed_version', 'ne', '') | list }}"
   loop_control:
     label: "{{ item.app_dir }}"
 
-- name: Install/upgrade Splunk add-ons from MinIO
+- name: Install/upgrade Splunk add-ons from object storage
   ansible.builtin.unarchive:
     src: "{{ splunk_docker_artifact_base_url }}/{{ item.filename }}"
     dest: "{{ splunk_docker_etc_dir }}/apps/"
     owner: "{{ splunk_docker_user }}"
     group: "{{ splunk_docker_group }}"
     remote_src: true
-  loop: "{{ splunk_docker_minio_decided | selectattr('_needs_install') | list }}"
+  loop: "{{ splunk_docker_object_storage_decided | selectattr('_needs_install') | list }}"
   loop_control:
     label: "{{ item.app_dir }} v{{ item.desired_version | default('manual') }}"
   notify: Restart Splunk container
@@ -140,11 +140,11 @@
 - name: Record installed version markers
   ansible.builtin.copy:
     content: "{{ item.desired_version or 'manual' }}\n"
-    dest: "{{ splunk_docker_etc_dir }}/apps/{{ item.app_dir }}/.minio_version"
+    dest: "{{ splunk_docker_etc_dir }}/apps/{{ item.app_dir }}/.object_storage_version"
     owner: "{{ splunk_docker_user }}"
     group: "{{ splunk_docker_group }}"
     mode: '0644'
-  loop: "{{ splunk_docker_minio_decided | selectattr('_needs_install') | list }}"
+  loop: "{{ splunk_docker_object_storage_decided | selectattr('_needs_install') | list }}"
   loop_control:
     label: "{{ item.app_dir }}"
 

--- a/roles/splunk_docker/vars/addons.yml
+++ b/roles/splunk_docker/vars/addons.yml
@@ -35,6 +35,7 @@ splunk_docker_addons:
   - {filename: Splunk_TA_H3_Unifi.tar, app_dir: Splunk_TA_H3_Unifi, splunkbase_id: 7935}
   - {filename: ubiquiti-add-on-for-splunk.tar, app_dir: TA-ubiquiti, splunkbase_id: 4107}
   - {filename: splunk-mcp-server.tar, app_dir: Splunk_MCP_Server, splunkbase_id: 7931, role: mcp_server}
+  - {filename: agent-management-versioned-app-retrieval.tar, app_dir: agent_management_versioned_app_retrieval, splunkbase_id: 8278}
   - {filename: python-for-scientific-computing-for-linux-64-bit.tar, app_dir: Splunk_SA_Scientific_Python_linux_x86_64, splunkbase_id: 2882}
   - {filename: splunk-ai-toolkit.tar, app_dir: Splunk_ML_Toolkit, splunkbase_id: 2890}
   - {filename: mltk-container.tar, app_dir: mltk-container, splunkbase_id: 4607}

--- a/roles/splunk_docker/vars/addons.yml
+++ b/roles/splunk_docker/vars/addons.yml
@@ -2,14 +2,14 @@
 # Splunk Add-on Registry
 #
 # Fields:
-#   filename       — archive name (in MinIO bucket, or github release asset).
+#   filename       — archive name (in object-storage bucket, or github release asset).
 #                    Version-free by convention; extension is cosmetic
 #                    (ansible.builtin.unarchive auto-detects gzip content).
 #   app_dir        — extracted directory name under /opt/splunk/etc/apps/.
 #                    Equals the Splunkbase `appid` for splunkbase entries.
 #   splunkbase_id  — Splunkbase numeric app ID. When present, playbooks/sync-splunkbase.yml
 #                    resolves the LATEST release from the public Splunkbase API and
-#                    mirrors it into MinIO. When absent, the entry is skipped by the
+#                    mirrors it into object storage. When absent, the entry is skipped by the
 #                    sync and must be populated manually.
 #   pin_version    — optional. Hard-pin to an exact version string to hold back a bad
 #                    release. When absent (the default), the entry tracks latest.
@@ -21,14 +21,14 @@
 #                    can change without breaking either lookup).
 #
 # Flow: sync-splunkbase.yml (control node, has internet) resolves the latest version
-# per splunkbase_id, downloads it, mirrors it to the MinIO `splunk-addons` bucket, and
+# per splunkbase_id, downloads it, mirrors it to the object-storage `splunk-addons` bucket, and
 # writes manifest.json mapping app_dir → version. The air-gapped Splunk VM then reads
 # manifest.json over the LAN and re-extracts any app whose installed version differs
 # (roles/splunk_docker/tasks/apps.yml). No manual downloads; no version bumps here —
 # add `pin_version` only to deliberately freeze a single app.
 
 splunk_docker_addons:
-  # --- MinIO, Splunkbase-sourced (auto-sync, tracks latest) ---
+  # --- object-storage, Splunkbase-sourced (auto-sync, tracks latest) ---
   - {filename: TA-unifi-cloud.tar, app_dir: TA-unifi-cloud, splunkbase_id: 7494}
   - {filename: duck-yeah.tar, app_dir: DuckYeah, splunkbase_id: 7015}
   - {filename: splunk-db-connect.tar, app_dir: splunk_app_db_connect, splunkbase_id: 2686}
@@ -54,9 +54,9 @@ splunk_docker_addons:
   - {filename: hurricane-labs-app-for-shodan.tar, app_dir: Hurricane_Labs_App_for_Shodan, splunkbase_id: 1767}
   - {filename: hurricane-labs-add-on-for-windows-powershell-transcript.tar, app_dir: TA-powershell_transcript, splunkbase_id: 4984}
 
-  # --- MinIO, no Splunkbase match (manual upload; sync skips) ---
+  # --- object-storage, no Splunkbase match (manual upload; sync skips) ---
   # Hurricane Labs' Automox add-on was removed from Splunkbase. The archive is
-  # still served from MinIO but must be re-uploaded manually with `mc cp` when
+  # still served from object storage but must be re-uploaded manually with `mc cp` when
   # a new version is needed.
   - {filename: hurricane-labs-add-on-for-automox.tar, app_dir: TA-automox}
 
@@ -64,7 +64,7 @@ splunk_docker_addons:
   # only via direct download (not Splunkbase, no GitHub release). To rotate
   # versions, repackage `~/git/splunk/TA-slack-add-on-for-splunk/` as an
   # uncompressed .tar archive (not .tar.gz — install uses the registry filename
-  # directly via ansible.builtin.unarchive) and upload to MinIO with the
+  # directly via ansible.builtin.unarchive) and upload to object storage with the
   # version-free filename:
   #   tar -cf slack-add-on-for-splunk.tar -C ~/git/splunk TA-slack-add-on-for-splunk
   #   mc cp slack-add-on-for-splunk.tar homelab/splunk-addons/slack-add-on-for-splunk.tar


### PR DESCRIPTION
Summary:
- Add Splunkbase app 8278 (Agent Management Versioned App Retrieval) to the Splunk add-on registry.
- Mirror it via the existing Splunkbase sync flow into `splunk-addons` as `agent-management-versioned-app-retrieval.tar`.

Checks:
- `nix develop github:JacobPEvans/nix-devenv#ansible-apps -c yamllint roles/splunk_docker/vars/addons.yml`
- `nix develop github:JacobPEvans/nix-devenv#ansible-apps -c ansible-playbook playbooks/sync-splunkbase.yml --syntax-check`
- Live sync: `nix develop github:JacobPEvans/nix-devenv#ansible-apps -c nix shell nixpkgs#minio-client -c env TOFU_INVENTORY_PATH=/Users/jevans/git/public/ansible-splunk/main/inventory/tofu_inventory.json doppler run -- ansible-playbook playbooks/sync-splunkbase.yml`