### PR TITLE
chore(hec): allow the llm token to write to llm_metrics

### DIFF
--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -119,6 +119,11 @@ splunk_docker_indexes:
   - name: llm
     max_size_mb: "{{ splunk_docker_index_default_max_size_mb }}"
     frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"
+    # Mac Studio LLM-stack metric events ride the llm-family Cribl output;
+    # the pipeline stamps index=llm_metrics on them, but they still arrive
+    # via the llm HEC token — so that token must also be allowed to write
+    # to the llm_metrics index.
+    extra_hec_indexes: [llm_metrics]
   # llm_metrics: LLM-stack metric series (Mac Studio + serving guests via the
   # llm-family Cribl output) — high-volume, 90-day retention matching
   # netmon_metrics. Splunkmetric -> metric index (mstats), NOT events.


### PR DESCRIPTION
Mac Studio metric events ride the llm-family Cribl output: the pipeline
stamps index=llm_metrics on them while they arrive through the llm HEC
token. Widen that token's allowlist with extra_hec_indexes so Splunk
does not reject the re-indexed events.

The llm_metrics index itself is declared in the monitoring-program
indexes change (feat/monitoring-program-indexes); merge that alongside
this so the allowlist references an existing index.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EbgZVVvmTwyhQNDLwuhFUv

> [!IMPORTANT]
> Stacked; merge together with (or after) feat/monitoring-program-indexes — references the llm_metrics index it creates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)