### PR TITLE
feat(alerts): add data-driven per-index silence detectors

### DIFF
--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -184,6 +184,77 @@ splunk_docker_indexes:
     frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs }}"
 
 
+# Per-index pipeline-silence detectors.
+# Each entry renders a [<name>_silence_detector] saved search (see
+# savedsearches.conf.j2) cloning the macos_edge_silence_detector shape:
+# tstats latest(_time) over the index, alert when silent beyond the
+# threshold. Fields:
+#   name              — stanza prefix; must not collide with the bespoke
+#                       detectors in savedsearches.conf.j2 (macos_edge,
+#                       llm_pipeline, llm_manager_panic, llm_router*).
+#   index             — index to watch.
+#   threshold_minutes — silence duration that fires the alert.
+#   cron              — schedule (keep period well below the threshold).
+#   suppress_minutes  — alert.suppress.period; throttles re-fires.
+#   by_host           — optional, default false. Detect PER-HOST (`by host`
+#                       + alert.suppress.fields = host) so a healthy emitter
+#                       can't mask a dead one. Note: a host that has never
+#                       emitted has no baseline and cannot be detected.
+#   disabled          — optional, default 0. Set 1 to ship the stanza
+#                       disabled (e.g. index exists but no emitter yet).
+#   sourcetype        — optional filter added to the tstats WHERE clause.
+splunk_docker_silence_detectors:
+  - name: unifi
+    index: unifi
+    threshold_minutes: 15
+    cron: "*/5 * * * *"
+    suppress_minutes: 60
+  - name: os
+    index: os
+    threshold_minutes: 15
+    cron: "*/5 * * * *"
+    suppress_minutes: 60
+    by_host: true
+  - name: claude
+    index: claude
+    threshold_minutes: 60
+    cron: "*/15 * * * *"
+    suppress_minutes: 240
+  - name: dns
+    index: dns
+    threshold_minutes: 30
+    cron: "*/10 * * * *"
+    suppress_minutes: 120
+  - name: proxy
+    index: proxy
+    threshold_minutes: 30
+    cron: "*/10 * * * *"
+    suppress_minutes: 120
+  - name: firewall
+    index: firewall
+    threshold_minutes: 60
+    cron: "*/15 * * * *"
+    suppress_minutes: 240
+  - name: netflow
+    index: netflow
+    threshold_minutes: 15
+    cron: "*/5 * * * *"
+    suppress_minutes: 60
+  # Audit trail is low-volume; a full day of silence is the signal.
+  - name: openbao_audit
+    index: openbao_audit
+    threshold_minutes: 1440
+    cron: "0 * * * *"
+    suppress_minutes: 1440
+  # No honeypot emitter is wired up yet — ship the stanza disabled so it
+  # can be flipped on (disabled: 0) when the deception fabric starts sending.
+  - name: honeypot
+    index: honeypot
+    threshold_minutes: 1440
+    cron: "0 * * * *"
+    suppress_minutes: 1440
+    disabled: 1
+
 # Firewall configuration
 # DISABLED: Proxmox firewall is the single source of truth for network security.
 # Guest-level iptables rules conflict with Docker's FORWARD chain and break

--- a/roles/splunk_docker/templates/savedsearches.conf.j2
+++ b/roles/splunk_docker/templates/savedsearches.conf.j2
@@ -198,7 +198,11 @@ action.email.message.alert = A promptfoo eval suite regressed: the latest score 
 {% for det in splunk_docker_silence_detectors | default([]) %}
 [{{ det.name }}_silence_detector]
 description = Alerts when the {{ det.index }} index has received no events for more than {{ det.threshold_minutes }} minutes{% if det.sourcetype is defined %} (sourcetype={{ det.sourcetype }}){% endif %}{% if det.by_host | default(false) %}, detected per-host so a healthy emitter cannot mask a dead one{% endif %}. Catches the emitter, its Cribl pipeline, and Splunk HEC ingestion failing with a single signal.
-search = | tstats latest(_time) as last_seen WHERE index={{ det.index }}{% if det.sourcetype is defined %} sourcetype={{ det.sourcetype }}{% endif %}{% if det.by_host | default(false) %} by host{% endif %} | eval minutes_silent = (now() - coalesce(last_seen, 0)) / 60 | where minutes_silent > {{ det.threshold_minutes }}
+{# The appendpipe guard covers the by_host blind spot: tstats ... by host over
+   a fully-empty index returns ZERO rows (not a null-last_seen row), so without
+   it the alert goes quiet exactly when every host is dead. stats count on the
+   empty set yields one count=0 row, which synthesizes a sentinel result. #}
+search = | tstats latest(_time) as last_seen WHERE index={{ det.index }}{% if det.sourcetype is defined %} sourcetype={{ det.sourcetype }}{% endif %}{% if det.by_host | default(false) %} by host | appendpipe [ stats count as _rows | where _rows == 0 | eval host = "(no hosts reporting)", last_seen = 0 | fields - _rows ]{% endif %} | eval minutes_silent = (now() - coalesce(last_seen, 0)) / 60 | where minutes_silent > {{ det.threshold_minutes }}
 # Lookback must exceed the worst-case silence the alert needs to detect;
 # tstats reads only indexed metadata, so a wide window is cheap.
 dispatch.earliest_time = -7d

--- a/roles/splunk_docker/templates/savedsearches.conf.j2
+++ b/roles/splunk_docker/templates/savedsearches.conf.j2
@@ -181,3 +181,50 @@ action.email.to = {{ splunk_docker_alert_email }}
 action.email.subject = [Splunk Alert] Model-eval score regression
 action.email.message.alert = A promptfoo eval suite regressed: the latest score for a model+suite fell more than 0.05 below the prior run (see the model / suite / score / prev_score fields). Review the recent model or routing-policy change that preceded the drop.
 {% endif %}
+
+{# ---------------------------------------------------------------------------
+   Generic per-index silence detectors.
+
+   One stanza per splunk_docker_silence_detectors entry (see defaults for the
+   field reference), cloning the macos_edge_silence_detector shape: tstats
+   latest(_time) over the index, fire when silence exceeds the threshold.
+   coalesce(last_seen, 0) makes an index with zero events in the whole
+   lookback window alert too — without it, tstats yields a null last_seen,
+   the where clause filters the row out, and the alert goes quiet exactly
+   when the emitter has been dead longest (the llm_router lesson). With
+   by_host, detection is per-host so a healthy emitter can't mask a dead
+   one; a host that has never emitted has no baseline and is not detected.
+--------------------------------------------------------------------------- #}
+{% for det in splunk_docker_silence_detectors | default([]) %}
+[{{ det.name }}_silence_detector]
+description = Alerts when the {{ det.index }} index has received no events for more than {{ det.threshold_minutes }} minutes{% if det.sourcetype is defined %} (sourcetype={{ det.sourcetype }}){% endif %}{% if det.by_host | default(false) %}, detected per-host so a healthy emitter cannot mask a dead one{% endif %}. Catches the emitter, its Cribl pipeline, and Splunk HEC ingestion failing with a single signal.
+search = | tstats latest(_time) as last_seen WHERE index={{ det.index }}{% if det.sourcetype is defined %} sourcetype={{ det.sourcetype }}{% endif %}{% if det.by_host | default(false) %} by host{% endif %} | eval minutes_silent = (now() - coalesce(last_seen, 0)) / 60 | where minutes_silent > {{ det.threshold_minutes }}
+# Lookback must exceed the worst-case silence the alert needs to detect;
+# tstats reads only indexed metadata, so a wide window is cheap.
+dispatch.earliest_time = -7d
+dispatch.latest_time = now
+cron_schedule = {{ det.cron }}
+enableSched = 1
+is_visible = 1
+disabled = {{ det.disabled | default(0) }}
+alert.severity = 3
+alert.suppress = 1
+alert.suppress.period = {{ det.suppress_minutes }}m
+{% if det.by_host | default(false) %}
+# Scope suppression per host: without this, the first silent host suppresses
+# the alert globally and a second host failing inside the window goes unseen.
+alert.suppress.fields = host
+{% endif %}
+alert.track = 1
+counttype = number of events
+relation = greater than
+quantity = 0
+{% if splunk_docker_alert_email %}
+action.email = 1
+action.email.to = {{ splunk_docker_alert_email }}
+action.email.subject = [Splunk Alert] {{ det.index }} index silent{% if det.by_host | default(false) %} (per-host){% endif %}
+
+action.email.message.alert = The {{ det.index }} index has received no events for {{ det.threshold_minutes }}+ minutes{% if det.by_host | default(false) %} from one or more hosts (see the host field in the results){% endif %}. Investigate the emitter, its Cribl pipeline, and Splunk HEC ingestion.
+{% endif %}
+
+{% endfor %}


### PR DESCRIPTION
Add splunk_docker_silence_detectors — a list of per-index silence
alerts rendered by a generic loop in savedsearches.conf.j2 that clones
the macos_edge_silence_detector shape (tstats latest(_time) over the
index, fire when silence exceeds the threshold). Two lessons from the
bespoke detectors are baked in:

- coalesce(last_seen, 0) (from llm_router_silence_detector) so an index
  with zero events in the whole lookback window still alerts instead of
  going quiet exactly when the emitter has been dead longest.
- optional by_host (from llm_pipeline_silence_detector): per-host
  detection plus alert.suppress.fields = host so a healthy emitter
  cannot mask a dead one.

Initial coverage: unifi 15m, os 15m (per-host), claude 60m, dns 30m,
proxy 30m, firewall 60m, netflow 15m, openbao_audit 24h, and honeypot
24h shipped disabled (no emitter wired up yet). Email delivery stays
gated on splunk_docker_alert_email like every existing alert. The
bespoke detectors are untouched and the generated stanza names do not
collide with them.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EbgZVVvmTwyhQNDLwuhFUv

> [!IMPORTANT]
> Stacked on feat/monitoring-program-indexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)