### PR TITLE
fix(apps): fail-soft guest-side add-on installs so config handlers still flush

### DIFF
--- a/roles/splunk_docker/tasks/apps.yml
+++ b/roles/splunk_docker/tasks/apps.yml
@@ -125,6 +125,14 @@
   loop_control:
     label: "{{ item.app_dir }}"
 
+# FAIL-SOFT (mirrors the controller-side rescue in sync-splunkbase.yml): a download
+# failure here — e.g. broken guest DNS making object storage / GitHub unreachable —
+# must NOT hard-fail the play. A hard fail aborts BEFORE the notified "Restart Splunk
+# container" handler flushes, so freshly deployed indexes/inputs/savedsearches config
+# never loads. We register the per-item results and `ignore_errors` so the converge
+# continues and every notified config handler still runs; a warning task below names
+# the add-ons that failed. Only these two download tasks are softened — no other task
+# type is masked. Failed add-ons keep their previously-installed version (or stay absent).
 - name: Install/upgrade Splunk add-ons from object storage
   ansible.builtin.unarchive:
     src: "{{ splunk_docker_artifact_base_url }}/{{ item.filename }}"
@@ -135,8 +143,12 @@
   loop: "{{ splunk_docker_object_storage_decided | selectattr('_needs_install') | list }}"
   loop_control:
     label: "{{ item.app_dir }} v{{ item.desired_version | default('manual') }}"
+  register: splunk_docker_object_storage_install
+  ignore_errors: true  # noqa: ignore-errors  # fail-soft: config handlers must still flush
   notify: Restart Splunk container
 
+# Only mark apps that actually extracted — a failed download must not record a marker,
+# or the next run would treat it as up to date and never retry.
 - name: Record installed version markers
   ansible.builtin.copy:
     content: "{{ item.desired_version or 'manual' }}\n"
@@ -144,9 +156,16 @@
     owner: "{{ splunk_docker_user }}"
     group: "{{ splunk_docker_group }}"
     mode: '0644'
-  loop: "{{ splunk_docker_object_storage_decided | selectattr('_needs_install') | list }}"
+  loop: >-
+    {{ splunk_docker_object_storage_decided | selectattr('_needs_install')
+       | rejectattr('app_dir', 'in', _splunk_docker_os_failed_dirs) | list }}
   loop_control:
     label: "{{ item.app_dir }}"
+  vars:
+    _splunk_docker_os_failed_dirs: >-
+      {{ splunk_docker_object_storage_install.results | default([])
+         | selectattr('failed', 'defined') | selectattr('failed')
+         | map(attribute='item.app_dir') | list }}
 
 # --- GitHub-release apps (VisiCore) — unchanged; see air-gap follow-up ---
 
@@ -161,7 +180,36 @@
   loop: "{{ splunk_docker_addons | selectattr('github_repo', 'defined') | list }}"
   loop_control:
     label: "{{ item.app_dir }}"
+  register: splunk_docker_github_install
+  ignore_errors: true  # noqa: ignore-errors  # fail-soft: config handlers must still flush
   notify: Restart Splunk container
+
+# Surface exactly which add-ons failed (from the registered loop results) and why the
+# converge is proceeding anyway, so a broken download is loud but non-fatal.
+- name: Warn about add-ons that failed to install (fail-soft)
+  ansible.builtin.debug:
+    msg: >-
+      Add-on install failed for [{{ _splunk_docker_failed_addons | join(', ') }}];
+      continuing the converge so config handlers (indexes/inputs/savedsearches +
+      Restart Splunk container) still flush. These add-ons keep their previously
+      installed version, or remain absent — re-run once object storage / GitHub is
+      reachable. Errors: {{ _splunk_docker_failed_details | join(' | ') }}
+  vars:
+    _splunk_docker_failed_addons: >-
+      {{ (splunk_docker_object_storage_install.results | default([])
+          | selectattr('failed', 'defined') | selectattr('failed')
+          | map(attribute='item.app_dir') | list)
+         + (splunk_docker_github_install.results | default([])
+          | selectattr('failed', 'defined') | selectattr('failed')
+          | map(attribute='item.app_dir') | list) }}
+    _splunk_docker_failed_details: >-
+      {{ (splunk_docker_object_storage_install.results | default([])
+          | selectattr('failed', 'defined') | selectattr('failed')
+          | map(attribute='msg') | list)
+         + (splunk_docker_github_install.results | default([])
+          | selectattr('failed', 'defined') | selectattr('failed')
+          | map(attribute='msg') | list) }}
+  when: _splunk_docker_failed_addons | length > 0
 
 # Splunk container runs as uid 41812; ensure every extracted app/TA is owned
 # by that user so the running process can read/write its own config.


### PR DESCRIPTION
## Problem

`roles/splunk_docker/tasks/apps.yml` installs add-ons target-side: the Splunk VM downloads each archive straight from object storage and GitHub releases via `unarchive` with `remote_src: true`. A download failure — e.g. the guest's DNS being broken so those hosts are unreachable — **hard-failed the play**. Because the play aborted, it stopped **before** the notified `Restart Splunk container` handler flushed, so freshly deployed `indexes.conf` / `inputs.conf` / `savedsearches.conf` never loaded. A transient download problem silently blocked every config change.

## Fix

Mirror the controller-side fail-soft precedent already in `playbooks/sync-splunkbase.yml` (the "Splunkbase sync failed — continue from existing object-storage contents" rescue), applied surgically to the guest side:

- Register the per-item results and add `ignore_errors: true` to **only** the two download tasks (object storage + GitHub). No other task type is masked.
- The converge now completes, so every notified config handler still runs.
- A new `Warn about add-ons that failed to install (fail-soft)` task names exactly which add-ons failed (from the loop results) and the errors, and explains why the converge proceeds.
- Version markers are only recorded for add-ons that actually extracted, so a failed download is retried on the next run instead of being frozen as "up to date".

## Related

The DNS defect that triggered this during the 2026-07-07 monitoring converge is tracked separately (guest resolv.conf points at stale pre-renumber resolvers). This change makes the play resilient regardless of that root cause.

## Validation

`ansible-lint --profile production roles/splunk_docker/tasks/apps.yml` → **Passed: 0 failure(s), 0 warning(s)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)