### PR TITLE
feat(splunk): mint per-user auth tokens for MCP service accounts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,13 +120,19 @@ ansible-lint
 
 ### Execution Performance & Optimization
 
-Ansible runs in this repo are generally fast since it targets a single VM. However, if running larger-scale validation or checking/deploying across multiple endpoints, keep these speed options in mind:
-1. **Parallel Execution (`--forks` or `ANSIBLE_FORKS`)**: Concurrency default is 5 hosts. Specifying a higher value (e.g. `--forks 25`) runs parallel checks faster.
-2. **Targeted Runs (`--limit`)**: Restrict playbook runs to specific target hosts (e.g., `--limit splunk-vm`).
-3. **Disable Fact Gathering**: If host facts aren't needed, setting `gather_facts: false` bypasses the slow setup step.
+Ansible runs in this repo are generally fast since it targets a single VM.
+However, if running larger-scale validation or checking/deploying across
+multiple endpoints, keep these speed options in mind:
+
+1. **Parallel Execution (`--forks` or `ANSIBLE_FORKS`)**: Concurrency default is
+   5 hosts. Specifying a higher value (e.g. `--forks 25`) runs parallel checks
+   faster.
+2. **Targeted Runs (`--limit`)**: Restrict playbook runs to specific target
+   hosts (e.g., `--limit splunk-vm`).
+3. **Disable Fact Gathering**: If host facts aren't needed, setting
+   `gather_facts: false` bypasses the slow setup step.
 
 ## Agent tasks
-
 
 ### Troubleshooting
 
@@ -188,7 +194,7 @@ All secrets retrieved from Doppler at runtime. Required secrets:
 | `SPLUNK_PASSWORD` | Admin password |
 | `HEC_NAMESPACE` | UUID namespace for per-index HEC token derivation (optional) |
 | `SPLUNK_HEC_TOKEN` | Shared legacy HEC token (always required) |
-| `SPLUNK_MCP_TOKEN` | MCP Server Bearer token (client-side, created via Splunk UI) |
+| `SPLUNK_MCP_TOKEN` | MCP Server Bearer token (client-side); minted per managed user (`splunk_docker_users`) and published to the secret store |
 | `PROXMOX_SSH_KEY_PATH` | SSH key for VM access |
 
 ## Tooling baseline (inherited from dryvist/.github)

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ All secrets via your Doppler config:
 | `SPLUNK_PASSWORD` | `splunk_docker_password` | Splunk admin password |
 | `HEC_NAMESPACE` | `splunk_docker_hec_namespace` | UUID namespace for per-index HEC token derivation (optional) |
 | `SPLUNK_HEC_TOKEN` | `splunk_docker_hec_token_values.legacy` | Shared legacy HEC token (always required) |
-| `SPLUNK_MCP_TOKEN` | — | MCP Server Bearer token (client-side, created via Splunk UI) |
+| `SPLUNK_MCP_TOKEN` | — | MCP Server Bearer token (client-side). Minted per managed user by the role — see [Managed service users](#managed-service-users) |
 | `PROXMOX_SSH_KEY_PATH` | — | SSH key for VM access |
 
 ```bash
@@ -151,6 +151,37 @@ doppler run -- ansible-playbook playbooks/site.yml
 > rotation you must reset the container admin via the standard
 > [user-seed.conf](https://docs.splunk.com/Documentation/Splunk/latest/Admin/User-seedconf)
 > procedure on the persistent `etc/` mount.
+
+## Managed service users
+
+Service accounts (AI agents, MCP clients) get their own scoped Splunk identity
+instead of sharing the admin password. Set `splunk_docker_manage_users: true`
+and list them in `splunk_docker_users`:
+
+```yaml
+splunk_docker_users:
+  - name: hermes
+    roles: [admin]   # narrow to a custom read/search role once known
+```
+
+After the REST API is up, the role (`tasks/manage_users.yml`) idempotently:
+
+1. **Enables token authentication** deployment-wide.
+2. **Creates each user** with its roles (password is random, set once at
+   creation — never rotated here, since the token is the real credential).
+3. **Mints an authorization token** (JWT) per user, tagged with
+   `splunk_docker_token_audience` (default `hermes-mcp`), skipping the mint when
+   a live token for that audience already exists.
+
+The minted JWT is the client-side `SPLUNK_MCP_TOKEN` the Splunk MCP Server
+(Splunkbase 7931) accepts as a Bearer token — a Splunk token inherits its
+owner's roles, so searches run with the user's capabilities. Because Splunk
+returns a token's value **only once at creation**, minting is gated on a
+delivery path: set `splunk_docker_token_publish_openbao: true` and provide a
+write-capable OpenBao AppRole (`BAO_ADDR` / `BAO_TOKEN`) so the role merges the
+token into `secret/ai/hermes` (`SPLUNK_MCP_TOKEN`) without clobbering sibling
+keys. Until that is wired, users and roles are still reconciled; only the
+token mint is deferred.
 
 ## Testing
 

--- a/inventory/group_vars/splunk.yml
+++ b/inventory/group_vars/splunk.yml
@@ -15,3 +15,13 @@ splunk_docker_mssql_driver_enabled: true
 # Data disk configuration
 splunk_data_disk_device: /dev/sdb1
 splunk_data_disk_mount_path: /opt/splunk/var/lib/splunk
+
+# Managed service users. The Hermes AI agent gets its own Splunk identity so it
+# can search/read the environment via the Splunk MCP Server (Bearer token =
+# SPLUNK_MCP_TOKEN, minted per-user). Admin role for now — narrow to a custom
+# read/search role once the access pattern is known.
+splunk_docker_manage_users: true
+splunk_docker_users:
+  - name: hermes
+    roles:
+      - admin

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -47,6 +47,40 @@ splunk_docker_hec_port: 8088
 splunk_docker_mgmt_port: 8089
 splunk_docker_mgmt_bind: "0.0.0.0"
 
+# --- Managed service users + auth tokens -----------------------------------
+# Create dedicated Splunk users (beyond the built-in admin) and mint each an
+# authorization token, so AI agents / MCP clients get their own scoped REST +
+# search identity instead of sharing the admin password. Off by default; the
+# splunk inventory group enables it and supplies the user list.
+splunk_docker_manage_users: false
+
+# List of managed users. Each: { name, roles: [..] }.
+#   name  - Splunk username (also the token owner / audience owner).
+#   roles - Splunk roles granted (e.g. [admin], [user], [power]).
+# The user's password is randomly generated once at creation and never rotated
+# here — the minted token is the credential that clients actually use.
+splunk_docker_users: []
+
+# Token audience tag used to detect an existing live token (idempotent mint) and
+# to label the token in Splunk. One token per (user, audience).
+splunk_docker_token_audience: "hermes-mcp"
+
+# Relative expiry for minted tokens (Splunk relative-time syntax, e.g. +90d).
+# Empty string omits expires_on so Splunk applies its default token lifetime.
+splunk_docker_token_expires_on: "+90d"
+
+# When true, publish a freshly minted token to OpenBao so the consumer (Hermes)
+# reads it from the shared secrets engine. Requires a write-capable OpenBao
+# AppRole in the converge environment (see the *_openbao_* vars below). Inert
+# by default: the user is created and the token minted, but the JWT is only
+# surfaced for out-of-band placement until a write role is wired.
+splunk_docker_token_publish_openbao: false
+splunk_docker_token_openbao_addr: "{{ lookup('env', 'BAO_ADDR') | default('', true) }}"
+splunk_docker_token_openbao_token: "{{ lookup('env', 'BAO_TOKEN') | default('', true) }}"
+splunk_docker_token_openbao_mount: "secret"
+splunk_docker_token_openbao_path: "ai/hermes"
+splunk_docker_token_openbao_key: "SPLUNK_MCP_TOKEN"
+
 # Splunk Web SSL (enableSplunkWebSSL)
 splunk_docker_web_ssl: true
 

--- a/roles/splunk_docker/tasks/main.yml
+++ b/roles/splunk_docker/tasks/main.yml
@@ -210,6 +210,11 @@
 - name: Configure MCP Server
   ansible.builtin.include_tasks: mcp_server.yml
 
+# Create dedicated service users (e.g. the Hermes AI agent) + mint their auth
+# tokens. Runs after the REST API is live (wait_for_splunk, above).
+- name: Manage Splunk service users and tokens
+  ansible.builtin.include_tasks: manage_users.yml
+
 # Configure DB Connect post-install (Java path for Task/Query servers)
 - name: Configure DB Connect
   ansible.builtin.include_tasks: dbconnect.yml

--- a/roles/splunk_docker/tasks/manage_one_user.yml
+++ b/roles/splunk_docker/tasks/manage_one_user.yml
@@ -1,0 +1,138 @@
+---
+# Create/reconcile ONE Splunk user and (when a delivery path exists) ensure it
+# has a live authorization token. Included per-item from manage_users.yml with
+# loop_var: splunk_user ({ name, roles: [..] }).
+
+- name: "Look up Splunk user {{ splunk_user.name }}"
+  ansible.builtin.uri:
+    url: "https://127.0.0.1:{{ splunk_docker_mgmt_port }}/services/authentication/users/{{ splunk_user.name }}?output_mode=json"
+    method: GET
+    user: "{{ splunk_admin_user | default('admin') }}"
+    password: "{{ splunk_docker_password }}"
+    force_basic_auth: true
+    validate_certs: false
+    status_code: [200, 404]
+  register: splunk_docker_user_lookup
+  no_log: true
+
+# Password is a fresh random string used ONLY at creation — the token is the
+# credential clients use, so the password is never stored or rotated here.
+- name: "Create Splunk user {{ splunk_user.name }}"
+  ansible.builtin.uri:
+    url: "https://127.0.0.1:{{ splunk_docker_mgmt_port }}/services/authentication/users"
+    method: POST
+    user: "{{ splunk_admin_user | default('admin') }}"
+    password: "{{ splunk_docker_password }}"
+    force_basic_auth: true
+    validate_certs: false
+    body_format: form-urlencoded
+    body:
+      name: "{{ splunk_user.name }}"
+      password: "{{ lookup('ansible.builtin.password', '/dev/null chars=ascii_letters,digits length=40') }}"
+      roles: "{{ splunk_user.roles }}"
+    status_code: [200, 201]
+  when: splunk_docker_user_lookup.status == 404
+  no_log: true
+
+- name: "Reconcile roles for Splunk user {{ splunk_user.name }}"
+  ansible.builtin.uri:
+    url: "https://127.0.0.1:{{ splunk_docker_mgmt_port }}/services/authentication/users/{{ splunk_user.name }}"
+    method: POST
+    user: "{{ splunk_admin_user | default('admin') }}"
+    password: "{{ splunk_docker_password }}"
+    force_basic_auth: true
+    validate_certs: false
+    body_format: form-urlencoded
+    body:
+      roles: "{{ splunk_user.roles }}"
+    status_code: [200]
+  when: splunk_docker_user_lookup.status == 200
+  no_log: true
+
+# A Splunk auth-token JWT is returned exactly once, at creation. So we only mint
+# when a delivery path exists (OpenBao publish on) — otherwise a minted token
+# would be un-deliverable and the audience check would suppress re-minting later.
+- name: "Ensure a live token for {{ splunk_user.name }}"
+  when: splunk_docker_token_publish_openbao | bool
+  block:
+    - name: "List existing tokens for {{ splunk_user.name }}"
+      ansible.builtin.uri:
+        url: "https://127.0.0.1:{{ splunk_docker_mgmt_port }}/services/authorization/tokens?output_mode=json"
+        method: GET
+        user: "{{ splunk_admin_user | default('admin') }}"
+        password: "{{ splunk_docker_password }}"
+        force_basic_auth: true
+        validate_certs: false
+        status_code: [200]
+      register: splunk_docker_token_list
+      no_log: true
+
+    - name: "Detect a live token for {{ splunk_user.name }} / {{ splunk_docker_token_audience }}"
+      ansible.builtin.set_fact:
+        splunk_docker_user_token_exists: >-
+          {{ (splunk_docker_token_list.json.entry | default([]))
+             | map(attribute='content.claims') | select('defined')
+             | selectattr('sub', 'defined') | selectattr('sub', 'equalto', splunk_user.name)
+             | selectattr('aud', 'defined') | selectattr('aud', 'equalto', splunk_docker_token_audience)
+             | list | length > 0 }}
+
+    - name: "Mint authorization token for {{ splunk_user.name }}"
+      ansible.builtin.uri:
+        url: "https://127.0.0.1:{{ splunk_docker_mgmt_port }}/services/authorization/tokens?output_mode=json"
+        method: POST
+        user: "{{ splunk_admin_user | default('admin') }}"
+        password: "{{ splunk_docker_password }}"
+        force_basic_auth: true
+        validate_certs: false
+        body_format: form-urlencoded
+        body:
+          name: "{{ splunk_user.name }}"
+          audience: "{{ splunk_docker_token_audience }}"
+          expires_on: "{{ splunk_docker_token_expires_on | default(omit) if (splunk_docker_token_expires_on | length > 0) else omit }}"
+        status_code: [200, 201]
+      register: splunk_docker_token_mint
+      when: not splunk_docker_user_token_exists
+      no_log: true
+
+    - name: "Read current OpenBao secret at {{ splunk_docker_token_openbao_path }}"
+      ansible.builtin.uri:
+        url: "{{ splunk_docker_token_openbao_addr }}/v1/{{ splunk_docker_token_openbao_mount }}/data/{{ splunk_docker_token_openbao_path }}"
+        method: GET
+        headers:
+          X-Vault-Token: "{{ splunk_docker_token_openbao_token }}"
+        validate_certs: false
+        status_code: [200, 404]
+      register: splunk_docker_bao_current
+      when:
+        - not splunk_docker_user_token_exists
+        - splunk_docker_token_mint is not skipped
+      no_log: true
+
+    # KV v2 write replaces the whole secret, so merge the new key over the
+    # current data to avoid clobbering sibling keys (e.g. HERMES_GITHUB_APP_*).
+    - name: "Publish {{ splunk_user.name }} token to OpenBao ({{ splunk_docker_token_openbao_key }})"
+      ansible.builtin.uri:
+        url: "{{ splunk_docker_token_openbao_addr }}/v1/{{ splunk_docker_token_openbao_mount }}/data/{{ splunk_docker_token_openbao_path }}"
+        method: POST
+        headers:
+          X-Vault-Token: "{{ splunk_docker_token_openbao_token }}"
+        body_format: json
+        body:
+          data: >-
+            {{ (splunk_docker_bao_current.json.data.data | default({}))
+               | combine({splunk_docker_token_openbao_key: splunk_docker_token_mint.json.entry[0].content.token}) }}
+        validate_certs: false
+        status_code: [200, 204]
+      when:
+        - not splunk_docker_user_token_exists
+        - splunk_docker_token_mint is not skipped
+      no_log: true
+
+- name: "Token delivery deferred for {{ splunk_user.name }}"
+  ansible.builtin.debug:
+    msg: >-
+      User '{{ splunk_user.name }}' ensured (roles {{ splunk_user.roles | join(',') }}).
+      Token minting is deferred because splunk_docker_token_publish_openbao is off —
+      wire a write-capable OpenBao AppRole (BAO_ADDR/BAO_TOKEN) to mint + publish
+      {{ splunk_docker_token_openbao_key }} to {{ splunk_docker_token_openbao_mount }}/{{ splunk_docker_token_openbao_path }}.
+  when: not (splunk_docker_token_publish_openbao | bool)

--- a/roles/splunk_docker/tasks/manage_users.yml
+++ b/roles/splunk_docker/tasks/manage_users.yml
@@ -1,0 +1,41 @@
+---
+# Manage additional Splunk users + mint per-user authorization tokens.
+#
+# Gives service accounts (e.g. the Hermes AI agent) their own scoped REST/search
+# identity instead of sharing the admin password. Included from tasks/main.yml
+# AFTER wait_for_splunk so the splunkd REST API is live.
+#
+# Auth model: the Splunk MCP Server (Splunkbase 7931, see vars/mcp.yml) lets MCP
+# clients authenticate with a Bearer token, NOT a username/password. So for each
+# managed user we (1) create the user with its roles, (2) enable token auth on
+# the deployment, and (3) mint a Splunk authorization token (JWT) that the client
+# uses as SPLUNK_MCP_TOKEN. The token inherits the user's roles/capabilities.
+
+- name: Manage Splunk service users and tokens
+  when:
+    - splunk_docker_manage_users | bool
+    - splunk_docker_users | length > 0
+  block:
+    # Token authentication must be enabled deployment-wide before any token can
+    # be minted. Idempotent — POSTing disabled=false when already enabled is a
+    # no-op 200.
+    - name: Enable Splunk token authentication
+      ansible.builtin.uri:
+        url: "https://127.0.0.1:{{ splunk_docker_mgmt_port }}/services/admin/token-auth/tokens_auth"
+        method: POST
+        user: "{{ splunk_admin_user | default('admin') }}"
+        password: "{{ splunk_docker_password }}"
+        force_basic_auth: true
+        validate_certs: false
+        body_format: form-urlencoded
+        body:
+          disabled: "false"
+        status_code: [200, 201]
+      no_log: true
+
+    - name: Reconcile each managed user and its token
+      ansible.builtin.include_tasks: manage_one_user.yml
+      loop: "{{ splunk_docker_users }}"
+      loop_control:
+        loop_var: splunk_user
+        label: "{{ splunk_user.name }}"


### PR DESCRIPTION
## What

Gives AI agents (starting with the Hermes agent) their own **scoped Splunk identity** — a dedicated user + a minted authorization token — instead of sharing the admin password. The token is the client-side Bearer the **Splunk MCP Server** (Splunkbase 7931, already deployed here) accepts, so an agent can run `run_splunk_query` / `get_indexes` / etc. with its own role's capabilities.

This automates the last manual step in the Splunk pipeline: `SPLUNK_MCP_TOKEN` was previously "created via the Splunk UI" and pasted into a secret store.

## How

New `roles/splunk_docker/tasks/manage_users.yml` + `manage_one_user.yml`, included after `wait_for_splunk` (REST API live). Idempotent, per user in `splunk_docker_users`:

1. **Enable token authentication** deployment-wide.
2. **Create the user** with its roles (password is random, set once at creation — never rotated here, since the token is the credential clients use).
3. **Reconcile roles** on every converge.
4. **Mint an authorization token**, tagged with `splunk_docker_token_audience` (`hermes-mcp`), skipped when a live token for that audience already exists.

The `splunk` group enables it with one admin-role `hermes` user (narrow to a custom read/search role once the access pattern is known).

## Token delivery (gated)

Splunk returns a token value **only once**, at creation, so the mint is gated on a delivery path. With `splunk_docker_token_publish_openbao: true` and a write-capable OpenBao AppRole (`BAO_ADDR`/`BAO_TOKEN`), the role read-modify-writes the JWT into `secret/ai/hermes` → `SPLUNK_MCP_TOKEN`, merging over existing keys so it never clobbers siblings. Until that write role is wired, users/roles still reconcile and only the mint is deferred (a debug task says so). This mirrors the existing GitHub-App-creds pattern (coded to read from the same OpenBao domain; runtime lights up when the write path exists).

The consumer side (Hermes `hermes mcp` client registration) lands in a follow-up `ansible-proxmox-apps` PR.

## Validation

- `yamllint` clean; `ansible-lint` **passes at production profile**.
- `markdownlint-cli2` clean (also fixes pre-existing MD013/MD032/MD012 errors in `AGENTS.md`).
- No secrets in the diff; all auth tasks `no_log`.

Live converge is the acceptance gate (creates the user, mints the token when the OpenBao write role is present).