### PR TITLE
fix(playbooks): stop play vars_files clobbering group_vars overrides

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -53,10 +53,17 @@
   # Load the role's index list up front so the per-index HEC token derivation
   # below can reference splunk_docker_indexes before the role is included
   # (mirrors playbooks/validate.yml).
-  vars_files:
-    - ../roles/splunk_docker/defaults/main.yml
+
 
   tasks:
+    # Precedence trap: play-level vars_files (#14) clobbers inventory group_vars (#6).
+    # Load defaults into a namespace here so pre-role tasks can fall back safely,
+    # preserving any group_vars overrides before the role executes.
+    - name: Load splunk_docker role defaults (namespaced, pre-role fallback)
+      ansible.builtin.include_vars:
+        file: ../roles/splunk_docker/defaults/main.yml
+        name: _splunk_docker_defaults
+
     - name: Validate required environment variables
       ansible.builtin.assert:
         that:
@@ -90,7 +97,7 @@
     # their per-index token one at a time, then legacy is retired.
     - name: Derive per-index HEC token values from namespace
       vars:
-        index_names: "{{ splunk_docker_indexes | map(attribute='name') | list }}"
+        index_names: "{{ (splunk_docker_indexes | default(_splunk_docker_defaults.splunk_docker_indexes)) | map(attribute='name') | list }}"
       ansible.builtin.set_fact:
         splunk_docker_hec_token_values: >-
           {{

--- a/playbooks/validate.yml
+++ b/playbooks/validate.yml
@@ -13,13 +13,18 @@
   become: true
   gather_facts: true
 
-  vars_files:
-    - ../roles/splunk_docker/defaults/main.yml
 
   vars:
     validation_results: []
 
   tasks:
+    # Precedence trap: play-level vars_files (#14) clobbers inventory group_vars (#6).
+    # Load defaults into a namespace here so pre-role tasks can fall back safely,
+    # preserving any group_vars overrides before the role executes.
+    - name: Load splunk_docker role defaults (namespaced, pre-role fallback)
+      ansible.builtin.include_vars:
+        file: ../roles/splunk_docker/defaults/main.yml
+        name: _splunk_docker_defaults
     - name: Set HEC namespace from environment
       ansible.builtin.set_fact:
         splunk_docker_hec_namespace: "{{ lookup('env', 'HEC_NAMESPACE') | default('', true) }}"
@@ -27,7 +32,7 @@
 
     - name: Derive per-index HEC token values from namespace
       vars:
-        index_names: "{{ splunk_docker_indexes | map(attribute='name') | list }}"
+        index_names: "{{ (splunk_docker_indexes | default(_splunk_docker_defaults.splunk_docker_indexes)) | map(attribute='name') | list }}"
       ansible.builtin.set_fact:
         splunk_docker_hec_token_values: >-
           {{
@@ -67,7 +72,7 @@
 
     - name: Check docker-compose.yml exists
       ansible.builtin.stat:
-        path: "{{ splunk_docker_config_dir }}/docker-compose.yml"
+        path: "{{ (splunk_docker_config_dir | default(_splunk_docker_defaults.splunk_docker_config_dir)) }}/docker-compose.yml"
       register: compose_file
 
     - name: Record docker-compose.yml status
@@ -76,49 +81,49 @@
 
     - name: Check HEC port is listening
       ansible.builtin.wait_for:
-        port: "{{ splunk_docker_hec_port }}"
+        port: "{{ (splunk_docker_hec_port | default(_splunk_docker_defaults.splunk_docker_hec_port)) }}"
         timeout: 5
       register: hec_port
       failed_when: false
 
     - name: Record HEC port status
       vars:
-        hec_check: "HEC port {{ splunk_docker_hec_port }} listening"
+        hec_check: "HEC port {{ (splunk_docker_hec_port | default(_splunk_docker_defaults.splunk_docker_hec_port)) }} listening"
       ansible.builtin.set_fact:
         validation_results: >-
           {{ validation_results + [{'check': hec_check, 'passed': hec_port.failed is false}] }}
 
     - name: Check Splunk web interface
       ansible.builtin.wait_for:
-        port: "{{ splunk_docker_web_port }}"
+        port: "{{ (splunk_docker_web_port | default(_splunk_docker_defaults.splunk_docker_web_port)) }}"
         timeout: 5
       register: web_port
       failed_when: false
 
     - name: Record web interface status
       vars:
-        web_check: "Web port {{ splunk_docker_web_port }} listening"
+        web_check: "Web port {{ (splunk_docker_web_port | default(_splunk_docker_defaults.splunk_docker_web_port)) }} listening"
       ansible.builtin.set_fact:
         validation_results: >-
           {{ validation_results + [{'check': web_check, 'passed': web_port.failed is false}] }}
 
     - name: Check management API port is listening
       ansible.builtin.wait_for:
-        port: "{{ splunk_docker_mgmt_port }}"
+        port: "{{ (splunk_docker_mgmt_port | default(_splunk_docker_defaults.splunk_docker_mgmt_port)) }}"
         timeout: 5
       register: mgmt_port
       failed_when: false
 
     - name: Record management port status
       vars:
-        mgmt_check: "Management API port {{ splunk_docker_mgmt_port }} listening"
+        mgmt_check: "Management API port {{ (splunk_docker_mgmt_port | default(_splunk_docker_defaults.splunk_docker_mgmt_port)) }} listening"
       ansible.builtin.set_fact:
         validation_results: >-
           {{ validation_results + [{'check': mgmt_check, 'passed': mgmt_port.failed is false}] }}
 
     - name: Test HEC endpoint per index token
       ansible.builtin.uri:
-        url: "https://localhost:{{ splunk_docker_hec_port }}/services/collector/event"
+        url: "https://localhost:{{ (splunk_docker_hec_port | default(_splunk_docker_defaults.splunk_docker_hec_port)) }}/services/collector/event"
         validate_certs: false
         method: POST
         headers:
@@ -131,7 +136,7 @@
         status_code: 200
       register: splunk_docker_hec_test
       failed_when: false
-      loop: "{{ splunk_docker_indexes }}"
+      loop: "{{ (splunk_docker_indexes | default(_splunk_docker_defaults.splunk_docker_indexes)) }}"
       loop_control:
         label: "{{ item.name }}"
       when: splunk_docker_hec_token_values[item.name] is defined
@@ -149,7 +154,7 @@
 
     - name: Test HEC endpoint with legacy token
       ansible.builtin.uri:
-        url: "https://localhost:{{ splunk_docker_hec_port }}/services/collector/event"
+        url: "https://localhost:{{ (splunk_docker_hec_port | default(_splunk_docker_defaults.splunk_docker_hec_port)) }}/services/collector/event"
         validate_certs: false
         method: POST
         headers:
@@ -181,7 +186,7 @@
 
     - name: Check web.conf exists
       ansible.builtin.stat:
-        path: "{{ splunk_docker_etc_dir }}/system/local/web.conf"
+        path: "{{ (splunk_docker_etc_dir | default(_splunk_docker_defaults.splunk_docker_etc_dir)) }}/system/local/web.conf"
       register: web_conf
 
     - name: Record web.conf status
@@ -190,7 +195,7 @@
 
     - name: Check indexes.conf exists
       ansible.builtin.stat:
-        path: "{{ splunk_docker_etc_dir }}/system/local/indexes.conf"
+        path: "{{ (splunk_docker_etc_dir | default(_splunk_docker_defaults.splunk_docker_etc_dir)) }}/system/local/indexes.conf"
       register: indexes_conf
 
     - name: Record indexes.conf status
@@ -199,14 +204,14 @@
 
     - name: Check firewall.sh exists
       ansible.builtin.stat:
-        path: "{{ splunk_docker_config_dir }}/firewall.sh"
+        path: "{{ (splunk_docker_config_dir | default(_splunk_docker_defaults.splunk_docker_config_dir)) }}/firewall.sh"
       register: firewall_script
-      when: splunk_docker_firewall_enabled | default(false)
+      when: (splunk_docker_firewall_enabled | default(_splunk_docker_defaults.splunk_docker_firewall_enabled)) | default(false)
 
     - name: Record firewall status
       ansible.builtin.set_fact:
         validation_results: "{{ validation_results + [{'check': 'Firewall configured', 'passed': firewall_script.stat.exists}] }}"
-      when: splunk_docker_firewall_enabled | default(false)
+      when: (splunk_docker_firewall_enabled | default(_splunk_docker_defaults.splunk_docker_firewall_enabled)) | default(false)
 
     - name: Load Splunk add-on registry
       ansible.builtin.include_vars:
@@ -215,7 +220,7 @@
 
     - name: Check Splunk add-ons are installed
       ansible.builtin.stat:
-        path: "{{ splunk_docker_etc_dir }}/apps/{{ item.app_dir }}"
+        path: "{{ (splunk_docker_etc_dir | default(_splunk_docker_defaults.splunk_docker_etc_dir)) }}/apps/{{ item.app_dir }}"
       loop: "{{ splunk_docker_addons }}"
       loop_control:
         label: "{{ item.app_dir }}"
@@ -253,7 +258,8 @@
       block:
         - name: Check MCP Server REST API responds
           ansible.builtin.uri:
-            url: "https://localhost:{{ splunk_docker_mgmt_port }}/services/apps/local/{{ mcp_app_dir }}"
+            url: >-
+              https://localhost:{{ (splunk_docker_mgmt_port | default(_splunk_docker_defaults.splunk_docker_mgmt_port)) }}/services/apps/local/{{ mcp_app_dir }}
             method: GET
             user: admin
             password: "{{ lookup('env', 'SPLUNK_PASSWORD') }}"
@@ -273,46 +279,52 @@
     - name: Check Java is accessible in Splunk container
       community.docker.docker_container_exec:
         container: splunk
-        command: "{{ splunk_docker_java_container_home }}/bin/java -version"
+        command: "{{ (splunk_docker_java_container_home | default(_splunk_docker_defaults.splunk_docker_java_container_home)) }}/bin/java -version"
       register: java_check
       failed_when: false
-      when: splunk_docker_java_enabled
+      when: (splunk_docker_java_enabled | default(_splunk_docker_defaults.splunk_docker_java_enabled))
 
     - name: Record Java availability status
       ansible.builtin.set_fact:
         validation_results: >-
           {{ validation_results + [{'check': 'Java accessible in container', 'passed': (java_check.rc | default(1)) == 0}] }}
-      when: splunk_docker_java_enabled
+      when: (splunk_docker_java_enabled | default(_splunk_docker_defaults.splunk_docker_java_enabled))
 
     - name: Check DB Connect JAVA_HOME configured in container
       community.docker.docker_container_exec:
         container: splunk
         user: root
         command: >-
-          grep -q "javaHome = {{ splunk_docker_java_container_home }}"
+          grep -q "javaHome = {{ (splunk_docker_java_container_home | default(_splunk_docker_defaults.splunk_docker_java_container_home)) }}"
           /opt/splunk/etc/apps/splunk_app_db_connect/local/dbx_settings.conf
       register: splunk_docker_dbconnect_check
       failed_when: false
-      when: splunk_docker_java_enabled
+      when: (splunk_docker_java_enabled | default(_splunk_docker_defaults.splunk_docker_java_enabled))
 
     - name: Record DB Connect JAVA_HOME status
       ansible.builtin.set_fact:
         validation_results: >-
           {{ validation_results + [{'check': 'DB Connect JAVA_HOME configured', 'passed': (splunk_docker_dbconnect_check.rc | default(1)) == 0}] }}
-      when: splunk_docker_java_enabled
+      when: (splunk_docker_java_enabled | default(_splunk_docker_defaults.splunk_docker_java_enabled))
 
     - name: Check MS SQL JDBC driver is present
       ansible.builtin.stat:
         path: >-
-          {{ splunk_docker_etc_dir }}/apps/splunk_app_db_connect/drivers/mssql-jdbc-{{ splunk_docker_mssql_driver_version }}.jar
+          {{ (splunk_docker_etc_dir | default(_splunk_docker_defaults.splunk_docker_etc_dir))
+          }}/apps/splunk_app_db_connect/drivers/mssql-jdbc-{{
+          (splunk_docker_mssql_driver_version | default(_splunk_docker_defaults.splunk_docker_mssql_driver_version)) }}.jar
       register: splunk_docker_mssql_driver_check
-      when: splunk_docker_java_enabled and splunk_docker_mssql_driver_enabled | default(false)
+      when:
+        - (splunk_docker_java_enabled | default(_splunk_docker_defaults.splunk_docker_java_enabled))
+        - (splunk_docker_mssql_driver_enabled | default(_splunk_docker_defaults.splunk_docker_mssql_driver_enabled)) | default(false)
 
     - name: Record MS SQL driver status
       ansible.builtin.set_fact:
         validation_results: >-
           {{ validation_results + [{'check': 'MS SQL JDBC driver installed', 'passed': splunk_docker_mssql_driver_check.stat.exists}] }}
-      when: splunk_docker_java_enabled and splunk_docker_mssql_driver_enabled | default(false)
+      when:
+        - (splunk_docker_java_enabled | default(_splunk_docker_defaults.splunk_docker_java_enabled))
+        - (splunk_docker_mssql_driver_enabled | default(_splunk_docker_defaults.splunk_docker_mssql_driver_enabled)) | default(false)
 
     - name: Get container disk usage
       ansible.builtin.command:


### PR DESCRIPTION
The play-level `vars_files` block has high precedence (#14), which causes it to silently clobber any variables set via inventory `group_vars` (#6).
This caused a live bug where `splunk_docker_manage_users` was set to `true` in `group_vars/splunk.yml`, but the play saw the role default (`false`) and skipped the manage_users tasks.

This fix removes `vars_files` from the plays and instead loads the role defaults safely into a `_splunk_docker_defaults` namespace using `include_vars` before the role runs. All pre-role tasks now use an explicit fallback to this namespace for those variables, preserving any overrides from `group_vars`.