### PR TITLE
fix(splunk): mint MCP tokens via the app mcp_token endpoint (aud=mcp)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,8 +140,7 @@ multiple endpoints, keep these speed options in mind:
 - **Apps not visible**: Verify ownership is UID 41812.
 - **HEC not working**: Confirm `SPLUNK_HEC_TOKEN` in Doppler; set
   `HEC_NAMESPACE` for per-index tokens.
-- **MCP Server not responding**: Create token via Splunk MCP Server
-  config page (Settings → MCP Server); confirm port 8089 is accessible.
+- **MCP Server not responding**: Verify token minting via the app's `/services/mcp_token` endpoint; confirm port 8089 is accessible and `SPLUNK_MCP_URL` points to the `<mgmt-base>/services/mcp` path.
 
 ### Adding Splunkbase apps
 
@@ -194,7 +193,7 @@ All secrets retrieved from Doppler at runtime. Required secrets:
 | `SPLUNK_PASSWORD` | Admin password |
 | `HEC_NAMESPACE` | UUID namespace for per-index HEC token derivation (optional) |
 | `SPLUNK_HEC_TOKEN` | Shared legacy HEC token (always required) |
-| `SPLUNK_MCP_TOKEN` | MCP Server Bearer token (client-side); minted per managed user (`splunk_docker_users`) and published to the secret store |
+| `SPLUNK_MCP_TOKEN` | MCP Server Bearer token (client-side); minted per managed user (`splunk_docker_users`) via the app's `/services/mcp_token` endpoint and published to the secret store. The SPLUNK_MCP_URL must be the `<mgmt-base>/services/mcp` path. |
 | `PROXMOX_SSH_KEY_PATH` | SSH key for VM access |
 
 ## Tooling baseline (inherited from dryvist/.github)

--- a/roles/splunk_docker/README.md
+++ b/roles/splunk_docker/README.md
@@ -105,7 +105,8 @@ python3 -c "import uuid; print(uuid.uuid5(uuid.UUID('$HEC_NAMESPACE'), 'splunk-h
 ## MCP Server Verification
 
 The Splunk MCP Server (app 7931) enables AI agents to query Splunk directly
-via the Model Context Protocol (MCP). Configure the MCP client in
+via the Model Context Protocol (MCP). The MCP JSON-RPC endpoint clients connect to is `<mgmt-base>/services/mcp` (e.g. `SPLUNK_MCP_URL=https://<host>:8089/services/mcp`).
+Tokens are minted via the app's `/services/mcp_token` endpoint. Configure the MCP client in
 `~/git/nix-ai/main/modules/mcp/default.nix`.
 
 ### Available MCP Tools

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -62,8 +62,9 @@ splunk_docker_manage_users: false
 splunk_docker_users: []
 
 # Token audience tag used to detect an existing live token (idempotent mint) and
-# to label the token in Splunk. One token per (user, audience).
-splunk_docker_token_audience: "hermes-mcp"
+# to label the token in Splunk. One token per (user, audience). Audience is DICTATED
+# by the MCP app (its auth only accepts mcp), not a free-form label.
+splunk_docker_token_audience: "mcp"
 
 # Relative expiry for minted tokens (Splunk relative-time syntax, e.g. +90d).
 # Empty string omits expires_on so Splunk applies its default token lifetime.

--- a/roles/splunk_docker/tasks/manage_one_user.yml
+++ b/roles/splunk_docker/tasks/manage_one_user.yml
@@ -78,17 +78,14 @@
 
     - name: "Mint authorization token for {{ splunk_user.name }}"
       ansible.builtin.uri:
-        url: "https://127.0.0.1:{{ splunk_docker_mgmt_port }}/services/authorization/tokens?output_mode=json"
-        method: POST
+        url: >-
+          https://127.0.0.1:{{ splunk_docker_mgmt_port }}/services/mcp_token?username={{ splunk_user.name }}{{
+          ('&expires_on=' ~ (splunk_docker_token_expires_on | urlencode)) if (splunk_docker_token_expires_on | length > 0) else '' }}
+        method: GET
         user: "{{ splunk_admin_user | default('admin') }}"
         password: "{{ splunk_docker_password }}"
         force_basic_auth: true
         validate_certs: false
-        body_format: form-urlencoded
-        body:
-          name: "{{ splunk_user.name }}"
-          audience: "{{ splunk_docker_token_audience }}"
-          expires_on: "{{ splunk_docker_token_expires_on | default(omit) if (splunk_docker_token_expires_on | length > 0) else omit }}"
         status_code: [200, 201]
       register: splunk_docker_token_mint
       when: not splunk_docker_user_token_exists
@@ -120,7 +117,7 @@
         body:
           data: >-
             {{ (splunk_docker_bao_current.json.data.data | default({}))
-               | combine({splunk_docker_token_openbao_key: splunk_docker_token_mint.json.entry[0].content.token}) }}
+               | combine({splunk_docker_token_openbao_key: splunk_docker_token_mint.json.token}) }}
         validate_certs: false
         status_code: [200, 204]
       when:

--- a/roles/splunk_docker/tasks/manage_users.yml
+++ b/roles/splunk_docker/tasks/manage_users.yml
@@ -8,8 +8,9 @@
 # Auth model: the Splunk MCP Server (Splunkbase 7931, see vars/mcp.yml) lets MCP
 # clients authenticate with a Bearer token, NOT a username/password. So for each
 # managed user we (1) create the user with its roles, (2) enable token auth on
-# the deployment, and (3) mint a Splunk authorization token (JWT) that the client
-# uses as SPLUNK_MCP_TOKEN. The token inherits the user's roles/capabilities.
+# the deployment, and (3) mint a Splunk authorization token (JWT) via the app's
+# /services/mcp_token endpoint that the client uses as SPLUNK_MCP_TOKEN.
+# The token inherits the user's roles/capabilities.
 
 - name: Manage Splunk service users and tokens
   when:

--- a/roles/splunk_docker/tasks/mcp_server.yml
+++ b/roles/splunk_docker/tasks/mcp_server.yml
@@ -3,8 +3,6 @@
 # Called from tasks/main.yml after apps.yml installs the app archive.
 #
 # Deploys optional local/mcp.conf settings (ssl_verify, rate limits).
-# Token management is handled entirely by the Splunk UI — this role
-# does NOT manage MCP authentication tokens.
 
 - name: Load MCP Server configuration vars
   ansible.builtin.include_vars:

--- a/roles/splunk_docker/vars/mcp.yml
+++ b/roles/splunk_docker/vars/mcp.yml
@@ -4,11 +4,9 @@
 # The MCP Server (Splunkbase app 7931) provides MCP tools for AI agents:
 # run_splunk_query, get_indexes, get_sourcetypes, etc.
 #
-# Token management is handled entirely by Splunk (UI or REST API).
-# Ansible deploys optional server settings (mcp.conf) but does NOT
-# manage authentication — tokens are RSA-encrypted JWTs created via
-# the Splunk MCP Server config page and stored in passwords.conf
-# by Splunk internally.
+# Ansible deploys optional server settings (mcp.conf) and manages
+# MCP authentication tokens for service users. Tokens are RSA-encrypted
+# JWTs created via the app's /services/mcp_token endpoint.
 #
 # The SPLUNK_MCP_TOKEN env var is a CLIENT-SIDE Bearer token used by
 # MCP clients (Claude Code, etc.) to connect to the server. It is not


### PR DESCRIPTION
The Splunk MCP Server app (Splunkbase 7931) rejects generic Splunk JWTs minted via `POST /services/authorization/tokens` because it explicitly validates the JWT `aud` claim and only accepts audience `mcp`.\n\nThis PR fixes the token minting flow by changing it to use the app's `GET /services/mcp_token` endpoint, which natively mints Splunk authorization tokens with the required `mcp` audience. We also updated the token registry logic to search for tokens with audience `mcp` for idempotent minting, and updated documentation.