### PR TITLE
chore(splunk): ship the netflow silence detector disabled

### DIFF
--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -275,11 +275,17 @@ splunk_docker_silence_detectors:
     threshold_minutes: 60
     cron: "*/15 * * * *"
     suppress_minutes: 240
+  # The gateway emits ZERO IPFIX despite NetFlow showing enabled in its
+  # console (a gateway-side export gap — the collector/receive chain is armed
+  # and idle; see tofu-unifi live/gateway-telemetry.tf). Structurally-empty
+  # index: ship the detector disabled so it stops firing on every cycle.
+  # Flip to disabled: 0 if the gateway ever starts exporting.
   - name: netflow
     index: netflow
     threshold_minutes: 15
     cron: "*/5 * * * *"
     suppress_minutes: 60
+    disabled: 1
   # Audit trail is low-volume; a full day of silence is the signal.
   - name: openbao_audit
     index: openbao_audit


### PR DESCRIPTION
## Why

`index=netflow` is structurally empty: the gateway emits **zero IPFIX packets** despite NetFlow showing enabled in its console. The entire receive chain (UDP LB :2055 → Stream `in_ipfix`) is armed and idle — a gateway-side export gap, with the desired-state record and diagnosis in tofu-unifi `live/gateway-telemetry.tf` (merged). A silence detector on an index that can never receive data fires on every cycle and only trains alert fatigue.

## What

Mark the `netflow` detector `disabled: 1` (same pattern as the `honeypot` stanza), with the rationale and re-enable condition in a comment. The index itself stays (90-day/50GB config) so nothing needs re-provisioning if the gateway ever starts exporting.

## Verification

- `ansible-lint` (production profile) green.
- Post-merge converge ships `[netflow_silence_detector]` with `disabled = 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)