### PR TITLE
fix(inventory): repoint containers['object-storage'] lookups to renamed key 's3'

### DIFF
--- a/playbooks/sync-splunkbase.yml
+++ b/playbooks/sync-splunkbase.yml
@@ -46,7 +46,7 @@
       MC_HOST_homelab: >-
         http://{{ lookup('env', 'OBJECT_STORAGE_ROOT_USER') }}:{{
         lookup('env', 'OBJECT_STORAGE_ROOT_PASSWORD') }}@{{
-        hostvars['localhost']['tofu_data']['containers']['object-storage']['ip'] }}:{{
+        hostvars['localhost']['tofu_data']['containers']['s3']['ip'] }}:{{
         hostvars['localhost']['tofu_data']['constants']['service_ports']['object_storage_s3'] }}
 
   tasks:

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -332,10 +332,8 @@ splunk_docker_mssql_driver_version: "12.8.1.jre11"
 # Custom add-ons with artifact_store: true are downloaded from this URL.
 # The splunk-addons bucket has an anonymous read policy on the internal network
 # (no auth needed). IP and port come from tofu inventory — no hardcoded values.
-# The container key is hyphenated, so bracket notation is required (dot notation
-# would mis-parse `object-storage` as subtraction).
 splunk_docker_artifact_base_url: >-
-  http://{{ tofu_data.containers['object-storage'].ip }}:{{
+  http://{{ tofu_data.containers['s3'].ip }}:{{
   tofu_data.constants.service_ports.object_storage_s3 }}/splunk-addons
 # VisiCore TA and App are downloaded from GitHub Releases (latest) automatically.
 # object-storage-sourced add-ons use version-free filenames — current version is


### PR DESCRIPTION
## What

The terraform-proxmox published ansible inventory is renaming the `containers` map key `object-storage` → `s3`. The container's hostname/FQDN (`s3.jacobpevans.com`) and all `service_ports` keys are **unchanged**, and the container **tag** `object-storage` is also unchanged (so tag-derived groups are unaffected). Only the map **key** used to look the container up changes.

This PR repoints the two `containers['object-storage']` key lookups in this repo:

- `roles/splunk_docker/defaults/main.yml:338` — `splunk_docker_artifact_base_url`
- `playbooks/sync-splunkbase.yml:49` — `mc_env.MC_HOST_homelab`

Also drops a now-false comment that justified bracket notation by the key being hyphenated (`s3` is not hyphenated).

## Coordination

**Do not merge alone.** This must merge **together with the upstream inventory republish** that renames the key. Merging before the inventory republishes would break the lookup (key `s3` not yet present); merging after but leaving this un-merged breaks it the other way. The orchestrator merges once the new-key inventory is published.

## Unchanged on purpose

`OBJECT_STORAGE_ROOT_USER/PASSWORD` env vars, the `object_storage_s3` service-port key, the `splunk-addons` bucket name, the `object-storage`/RustFS prose, and all CHANGELOG entries — none are containers-map key lookups.