### PR TITLE
feat(splunk): add Traefik Splunkbase app

### DIFF
--- a/playbooks/sync-splunkbase.yml
+++ b/playbooks/sync-splunkbase.yml
@@ -268,7 +268,7 @@
             cmd: >-
               mc tag set
               homelab/{{ object_storage_bucket }}/{{ item.filename }}
-              version={{ item.desired_version | string | urlencode }}&splunkbase_id={{ item.splunkbase_id }}
+              version={{ item.desired_version | string | trim }}&splunkbase_id={{ item.splunkbase_id }}
           environment: "{{ mc_env }}"
           loop: "{{ splunkbase_to_sync }}"
           loop_control:
@@ -369,21 +369,24 @@
       environment: "{{ mc_env }}"
       register: object_storage_manifest_verify
       changed_when: false
+      failed_when: false
       when: splunkbase_manifest is defined
       no_log: true
 
     - name: Verify published manifest matches resolved Splunkbase versions
       ansible.builtin.assert:
         that:
+          - object_storage_manifest_verify.rc == 0
           - >-
-            ((object_storage_manifest_verify.stdout | from_json).get(item.app_dir, {}).version
+            ((object_storage_manifest_verify.stdout | default('{}', true) | from_json).get(item.app_dir, {}).version
             | default('') | trim) == (item.desired_version | string | trim)
           - >-
-            ((object_storage_manifest_verify.stdout | from_json).get(item.app_dir, {}).filename
+            ((object_storage_manifest_verify.stdout | default('{}', true) | from_json).get(item.app_dir, {}).filename
             | default('') | trim) == (item.filename | string | trim)
         fail_msg: >-
           manifest.json mismatch for {{ item.app_dir }}:
-          expected {{ item.filename }} at {{ item.desired_version }}.
+          expected {{ item.filename }} at {{ item.desired_version }}
+          ({{ 'manifest unreadable' if object_storage_manifest_verify.rc != 0 else 'value drift' }}).
         quiet: true
       loop: "{{ splunkbase_desired | default([]) }}"
       loop_control:

--- a/playbooks/sync-splunkbase.yml
+++ b/playbooks/sync-splunkbase.yml
@@ -350,12 +350,12 @@
         that:
           - item.rc == 0
           - >-
-            ((item.stdout | default('{}') | from_json).tagset.version
+            ((item.stdout | default('{}', true) | from_json).tagset.version
             | default('') | trim) == (item.item.desired_version | string | trim)
         fail_msg: >-
           object-storage version mismatch for {{ item.item.filename }}:
           expected {{ item.item.desired_version }}, got
-          {{ ((item.stdout | default('{}') | from_json).tagset.version
+          {{ ((item.stdout | default('{}', true) | from_json).tagset.version
              | default('(missing)') | trim) if item.rc == 0 else '(missing object)' }}.
         quiet: true
       loop: "{{ object_storage_final_tag_query.results | default([]) }}"

--- a/playbooks/sync-splunkbase.yml
+++ b/playbooks/sync-splunkbase.yml
@@ -268,7 +268,7 @@
             cmd: >-
               mc tag set
               homelab/{{ object_storage_bucket }}/{{ item.filename }}
-              version={{ item.desired_version }}&splunkbase_id={{ item.splunkbase_id }}
+              version={{ item.desired_version | string | urlencode }}&splunkbase_id={{ item.splunkbase_id }}
           environment: "{{ mc_env }}"
           loop: "{{ splunkbase_to_sync }}"
           loop_control:
@@ -331,3 +331,61 @@
               Splunkbase resolve/sync failed; leaving the bucket + manifest.json as-is and
               proceeding with whatever is already mirrored. Error:
               {{ ansible_failed_result.msg | default('see preceding task') }}
+
+    - name: Query final object-storage version tags
+      ansible.builtin.command:
+        cmd: "mc tag list --json homelab/{{ object_storage_bucket }}/{{ item.filename }}"
+      environment: "{{ mc_env }}"
+      loop: "{{ splunkbase_desired | default([]) }}"
+      loop_control:
+        label: "{{ item.filename }}"
+      register: object_storage_final_tag_query
+      changed_when: false
+      failed_when: false
+      when: splunkbase_manifest is defined
+      no_log: true
+
+    - name: Verify object-storage tags match resolved Splunkbase versions
+      ansible.builtin.assert:
+        that:
+          - item.rc == 0
+          - >-
+            ((item.stdout | default('{}') | from_json).tagset.version
+            | default('') | trim) == (item.item.desired_version | string | trim)
+        fail_msg: >-
+          object-storage version mismatch for {{ item.item.filename }}:
+          expected {{ item.item.desired_version }}, got
+          {{ ((item.stdout | default('{}') | from_json).tagset.version
+             | default('(missing)') | trim) if item.rc == 0 else '(missing object)' }}.
+        quiet: true
+      loop: "{{ object_storage_final_tag_query.results | default([]) }}"
+      loop_control:
+        label: "{{ item.item.filename }}"
+      when: splunkbase_manifest is defined
+
+    - name: Read published object-storage manifest
+      ansible.builtin.command:
+        cmd: "mc cat homelab/{{ object_storage_bucket }}/manifest.json"
+      environment: "{{ mc_env }}"
+      register: object_storage_manifest_verify
+      changed_when: false
+      when: splunkbase_manifest is defined
+      no_log: true
+
+    - name: Verify published manifest matches resolved Splunkbase versions
+      ansible.builtin.assert:
+        that:
+          - >-
+            ((object_storage_manifest_verify.stdout | from_json).get(item.app_dir, {}).version
+            | default('') | trim) == (item.desired_version | string | trim)
+          - >-
+            ((object_storage_manifest_verify.stdout | from_json).get(item.app_dir, {}).filename
+            | default('') | trim) == (item.filename | string | trim)
+        fail_msg: >-
+          manifest.json mismatch for {{ item.app_dir }}:
+          expected {{ item.filename }} at {{ item.desired_version }}.
+        quiet: true
+      loop: "{{ splunkbase_desired | default([]) }}"
+      loop_control:
+        label: "{{ item.app_dir }}"
+      when: splunkbase_manifest is defined

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -333,7 +333,7 @@ splunk_docker_mssql_driver_version: "12.8.1.jre11"
 # The splunk-addons bucket has an anonymous read policy on the internal network
 # (no auth needed). IP and port come from tofu inventory — no hardcoded values.
 splunk_docker_artifact_base_url: >-
-  http://{{ tofu_data.containers['s3'].ip }}:{{
+  http://{{ tofu_data.containers['s3'].reserved_ip | default(tofu_data.containers['s3'].ip) }}:{{
   tofu_data.constants.service_ports.object_storage_s3 }}/splunk-addons
 # VisiCore TA and App are downloaded from GitHub Releases (latest) automatically.
 # object-storage-sourced add-ons use version-free filenames — current version is

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -333,7 +333,7 @@ splunk_docker_mssql_driver_version: "12.8.1.jre11"
 # The splunk-addons bucket has an anonymous read policy on the internal network
 # (no auth needed). IP and port come from tofu inventory — no hardcoded values.
 splunk_docker_artifact_base_url: >-
-  http://{{ tofu_data.containers['s3'].reserved_ip | default(tofu_data.containers['s3'].ip) }}:{{
+  http://{{ tofu_data.containers['s3'].reserved_ip | default(tofu_data.containers['s3'].ip, true) }}:{{
   tofu_data.constants.service_ports.object_storage_s3 }}/splunk-addons
 # VisiCore TA and App are downloaded from GitHub Releases (latest) automatically.
 # object-storage-sourced add-ons use version-free filenames — current version is

--- a/roles/splunk_docker/vars/addons.yml
+++ b/roles/splunk_docker/vars/addons.yml
@@ -36,6 +36,7 @@ splunk_docker_addons:
   - {filename: ubiquiti-add-on-for-splunk.tar, app_dir: TA-ubiquiti, splunkbase_id: 4107}
   - {filename: splunk-mcp-server.tar, app_dir: Splunk_MCP_Server, splunkbase_id: 7931, role: mcp_server}
   - {filename: agent-management-versioned-app-retrieval.tar, app_dir: agent_management_versioned_app_retrieval, splunkbase_id: 8278}
+  - {filename: add-on-for-traefik-proxy.tar, app_dir: splunk_traefik_addon, splunkbase_id: 6733}
   - {filename: python-for-scientific-computing-for-linux-64-bit.tar, app_dir: Splunk_SA_Scientific_Python_linux_x86_64, splunkbase_id: 2882}
   - {filename: splunk-ai-toolkit.tar, app_dir: Splunk_ML_Toolkit, splunkbase_id: 2890}
   - {filename: mltk-container.tar, app_dir: mltk-container, splunkbase_id: 4607}


### PR DESCRIPTION
Summary
- Add Splunkbase app 6733 (Add On for Traefik Proxy) to the object-storage-backed registry.
- Harden `playbooks/sync-splunkbase.yml` so RustFS tags and `manifest.json` must match resolved Splunkbase versions after sync.
- Use the LAN-resolvable object-storage IP from tofu inventory for target-side installs.

Tests
- `yamllint roles/splunk_docker/defaults/main.yml roles/splunk_docker/vars/addons.yml playbooks/sync-splunkbase.yml`
- `ansible-playbook playbooks/sync-splunkbase.yml --syntax-check`
- `ansible-playbook playbooks/site.yml --syntax-check`
- `ansible-lint playbooks/sync-splunkbase.yml playbooks/site.yml`
- `git diff --check`
- Live sync + deploy against the Splunk VM with pinned tofu inventory
- One-time live comparison: 25 Splunkbase-backed add-ons checked, 0 mismatches; Traefik installed at 0.100.0

Notes
- `playbooks/validate.yml` still has an unrelated HEC/defaults issue in the existing repo and fails there after the port checks pass.