### PR TITLE
feat(splunk): serving memory-headroom + Metal ceiling alerts

### DIFF
--- a/roles/splunk_docker/templates/savedsearches.conf.j2
+++ b/roles/splunk_docker/templates/savedsearches.conf.j2
@@ -232,3 +232,49 @@ action.email.message.alert = The {{ det.index }} index has received no events fo
 {% endif %}
 
 {% endfor %}
+[llm_serving_memory_headroom]
+description = Warns BEFORE the serving host's memory reaches the Metal cache-clear trip (~85% of a 128 GB host = ~109 GB). Rides the mlx:metrics system-metrics feed (node_memory_used_percent) so it works even while the vllm-mlx log input is broken (nix-darwin#1623). Sustained-average over 5 minutes so a single load spike (a model swap-in) does not page anyone.
+search = index=llm sourcetype=mlx:metrics node_memory_used_percent=* | stats avg(node_memory_used_percent) as used_pct by host | where used_pct > 85
+dispatch.earliest_time = -5m
+dispatch.latest_time = now
+cron_schedule = */5 * * * *
+enableSched = 1
+is_visible = 1
+disabled = 0
+alert.severity = 4
+alert.suppress = 1
+alert.suppress.period = 60m
+alert.suppress.fields = host
+alert.track = 1
+counttype = number of events
+relation = greater than
+quantity = 0
+{% if splunk_docker_alert_email %}
+action.email = 1
+action.email.to = {{ splunk_docker_alert_email }}
+action.email.subject = [Splunk Alert] LLM serving host near memory ceiling
+action.email.message.alert = A serving host's 5-minute average memory use exceeds 85% (see host + used_pct in results) — the Metal cache-clear trip sits at ~85% of device memory, so serving quality degrades next. Check resident model composition (/running via the gate), the daily brain-rotation phase, and idle-unload behavior before the trip fires.
+{% endif %}
+
+[llm_metal_resource_limit_detector]
+description = Fires on any MLX Metal buffer-count ceiling error ("[metal::malloc] Resource limit (499000) exceeded") reaching the llm index — the mid-stream-abort failure mode the 2026-07 serving fixes (buffer-cache cap + paged-block sizing) are meant to make impossible. Zero-noise by design: any single event is a regression worth investigating. Depends on the vllm-mlx log input (nix-darwin#1623); inert until that delivers.
+search = index=llm "Resource limit (499000)"
+dispatch.earliest_time = -15m
+dispatch.latest_time = now
+cron_schedule = */5 * * * *
+enableSched = 1
+is_visible = 1
+disabled = 0
+alert.severity = 5
+alert.suppress = 1
+alert.suppress.period = 60m
+alert.track = 1
+counttype = number of events
+relation = greater than
+quantity = 0
+{% if splunk_docker_alert_email %}
+action.email = 1
+action.email.to = {{ splunk_docker_alert_email }}
+action.email.subject = [Splunk Alert] Metal buffer-count ceiling tripped on a serving host
+action.email.message.alert = A vllm-mlx worker hit the Metal buffer-count ceiling (Resource limit 499000) — requests are aborting mid-stream. This regression was supposed to be impossible after the 2026-07 buffer-cache/block-size fixes; check concurrent long-context load, MLX_BUFFER_CACHE_LIMIT in the worker env, and paged-cache block sizes (nix-ai catalog).
+{% endif %}


### PR DESCRIPTION
## Why

Goal: serving limits should warn **before** the Mac is actually near capacity, and a Metal buffer-count trip (`[metal::malloc] Resource limit (499000)`) should be treated as a regression the moment it recurs (the 2026-07 fixes — MLX_BUFFER_CACHE_LIMIT + paged-block sizing — are meant to make it impossible).

## What

Two saved searches in `savedsearches.conf.j2` (existing alert pattern):
- **llm_serving_memory_headroom** — per-host 5-min avg `node_memory_used_percent > 85` (the Metal cache-clear trip ≈ 85% of device memory). Rides the `mlx:metrics` feed that already flows, so it works today.
- **llm_metal_resource_limit_detector** — severity-5, fires on any `Resource limit (499000)` event in index=llm. Inert until the vllm-mlx log input delivers ([nix-darwin#1623](https://github.com/dryvist/nix-darwin/issues/1623)).

## Verification

- `ansible-lint` production profile: 0 failures.
- Post-converge: both searches appear under Settings → Searches; the headroom search returns rows when a host crosses 85% (verified against live mlx:metrics data shape).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013oEWqS9KGW6hsSuPsKtfxr