### PR TITLE
feat(splunk): cluster rank-error + idle-cluster saved searches

### DIFF
--- a/roles/splunk_docker/templates/savedsearches.conf.j2
+++ b/roles/splunk_docker/templates/savedsearches.conf.j2
@@ -278,3 +278,49 @@ action.email.to = {{ splunk_docker_alert_email }}
 action.email.subject = [Splunk Alert] Metal buffer-count ceiling tripped on a serving host
 action.email.message.alert = A vllm-mlx worker hit the Metal buffer-count ceiling (Resource limit 499000) — requests are aborting mid-stream. This regression was supposed to be impossible after the 2026-07 buffer-cache/block-size fixes; check concurrent long-context load, MLX_BUFFER_CACHE_LIMIT in the worker env, and paged-cache block sizes (nix-ai catalog).
 {% endif %}
+
+[llm_night_rank_error_detector]
+description = Fires on night-cluster rank/link-watcher errors (JACCL init failures, rank crashes, distributed aborts) in the night logs shipped by the serving hosts' in_night_logs input. Zero-noise by design: the night fabric is supposed to converge silently, so any error line is worth a look before the next plug night.
+search = index=llm source=*mlx-night* (ERROR OR error OR Traceback OR "night-link: rank not running")
+dispatch.earliest_time = -15m
+dispatch.latest_time = now
+cron_schedule = */15 * * * *
+enableSched = 1
+is_visible = 1
+disabled = 0
+alert.severity = 4
+alert.suppress = 1
+alert.suppress.period = 60m
+alert.track = 1
+counttype = number of events
+relation = greater than
+quantity = 0
+{% if splunk_docker_alert_email %}
+action.email = 1
+action.email.to = {{ splunk_docker_alert_email }}
+action.email.subject = [Splunk Alert] Night-cluster rank/watcher errors
+action.email.message.alert = The two-Mac night cluster logged errors (rank crash, JACCL failure, or repeated watcher kickstarts). The fabric falls back to the solo brain automatically, but the night capacity is degraded — check night-rank.error.log on both Macs before the next plug night.
+{% endif %}
+
+[llm_night_idle_cluster_detector]
+description = "Night mode active but unused": the night rank has been up (rank log activity in the last hour) yet the gate's night endpoint saw zero completions in 30 minutes. Cluster capacity is burning memory on both Macs while Hermes/router traffic is not reaching it — usually a router flag (ai_night_brain_enabled) or fallback chain issue.
+search = index=llm source=*mlx-night*night-rank* earliest=-60m | stats count as rank_activity | appendcols [ search index=llm source=*night-access* earliest=-30m | stats count as night_requests ] | where rank_activity > 0 AND night_requests = 0
+dispatch.earliest_time = -60m
+dispatch.latest_time = now
+cron_schedule = */30 * * * *
+enableSched = 1
+is_visible = 1
+disabled = 0
+alert.severity = 3
+alert.suppress = 1
+alert.suppress.period = 120m
+alert.track = 1
+counttype = number of events
+relation = greater than
+quantity = 0
+{% if splunk_docker_alert_email %}
+action.email = 1
+action.email.to = {{ splunk_docker_alert_email }}
+action.email.subject = [Splunk Alert] Night cluster up but receiving no traffic
+action.email.message.alert = The night rank is running but the gated night endpoint served nothing for 30 minutes. Check the router large-phase config (night deployment + fallbacks) and whether the fallback chain silently drained all traffic to the solo brain.
+{% endif %}

--- a/roles/splunk_docker/templates/savedsearches.conf.j2
+++ b/roles/splunk_docker/templates/savedsearches.conf.j2
@@ -281,7 +281,7 @@ action.email.message.alert = A vllm-mlx worker hit the Metal buffer-count ceilin
 
 [llm_night_rank_error_detector]
 description = Fires on night-cluster rank/link-watcher errors (JACCL init failures, rank crashes, distributed aborts) in the night logs shipped by the serving hosts' in_night_logs input. Zero-noise by design: the night fabric is supposed to converge silently, so any error line is worth a look before the next plug night.
-search = index=llm source=*mlx-night* (ERROR OR error OR Traceback OR "night-link: rank not running")
+search = index=llm source=*mlx-night* (error OR Traceback OR "night-link: rank not running")
 dispatch.earliest_time = -15m
 dispatch.latest_time = now
 cron_schedule = */15 * * * *
@@ -304,7 +304,7 @@ action.email.message.alert = The two-Mac night cluster logged errors (rank crash
 
 [llm_night_idle_cluster_detector]
 description = "Night mode active but unused": the night rank has been up (rank log activity in the last hour) yet the gate's night endpoint saw zero completions in 30 minutes. Cluster capacity is burning memory on both Macs while Hermes/router traffic is not reaching it — usually a router flag (ai_night_brain_enabled) or fallback chain issue.
-search = index=llm source=*mlx-night*night-rank* earliest=-60m | stats count as rank_activity | appendcols [ search index=llm source=*night-access* earliest=-30m | stats count as night_requests ] | where rank_activity > 0 AND night_requests = 0
+search = index=llm (source=*mlx-night*night-rank* OR source=*night-access*) | stats count(eval(if(match(source, "night-rank"), 1, null()))) as rank_activity, count(eval(if(match(source, "night-access") AND _time >= relative_time(now(), "-30m@m"), 1, null()))) as night_requests | where rank_activity > 0 AND night_requests = 0
 dispatch.earliest_time = -60m
 dispatch.latest_time = now
 cron_schedule = */30 * * * *


### PR DESCRIPTION
## Summary

Observability half of the cluster design (companions: dryvist/nix-ai#1173, dryvist/ansible-proxmox-apps#838, nix-darwin host PR): two saved searches over the cluster logs the serving hosts ship via the new dedicated Cribl input and the gate's cluster access log.

- **Rank-error detector** (sev 4, 15-min cadence): any JACCL/rank/watcher error line. Zero-noise design — the cluster fabric converges silently or something is wrong.
- **Idle-cluster detector** (sev 3, 30-min cadence): rank active but zero gated cluster-endpoint completions in 30 min — cluster present, router not using it (flag or fallback-chain issue).

## Deviation from plan

The quiesce-violation search is omitted: no worker process-table telemetry reaches Splunk today, so it would be inert config. The pre-plug dry-run asserts the allowlist manually (runbook step); revisit if worker process telemetry ever ships.

## Verification

- `ansible-lint` production profile: 0 failures on the role.
- Search syntax follows the existing #326 stanzas (same suppress/track/email-guard shape); both stanzas render under the same `splunk_docker_alert_email` guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLeWAhEN9MsTchNU4n1nGY
