### PR TITLE
feat(splunk): add TA Studio splunkbase app

### DIFF
--- a/.github/workflows/ai-pr-care.yml
+++ b/.github/workflows/ai-pr-care.yml
@@ -1,3 +1,4 @@
+---
 # AI PR care: dependency risk review + release highlights.
 #
 # - cc-dep-review: one AI risk-assessment comment on Renovate major/minor PRs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,8 +84,6 @@ documented once at
 | --- | --- |
 | Index definitions | `roles/splunk_docker/defaults/main.yml` |
 | Add-on registry | `roles/splunk_docker/vars/addons.yml` |
-| Splunkbase app registry | `roles/splunk_docker/vars/splunkbase_apps.yml` |
-| Custom TA definitions | `roles/splunk_docker/vars/custom_addons.yml` |
 | MCP Server configuration | `roles/splunk_docker/vars/mcp.yml` |
 | Inventory | `inventory/load_tofu.yml` |
 | Pipeline architecture | `~/git/CLAUDE.md` |
@@ -144,17 +142,16 @@ multiple endpoints, keep these speed options in mind:
 
 ### Adding Splunkbase apps
 
-1. Edit `roles/splunk_docker/vars/splunkbase_apps.yml` — add entry or
-   set `enabled: true`.
-2. Download archive from Splunkbase and place it in
-   `roles/splunk_docker/files/`.
+1. Add the app entry to `roles/splunk_docker/vars/addons.yml` under `splunk_docker_addons` with its `filename`, `app_dir`, and `splunkbase_id`.
+2. Sync the app to object storage: `doppler run -- ansible-playbook playbooks/sync-splunkbase.yml`.
 3. Re-run `doppler run -- ansible-playbook playbooks/site.yml`.
 
 ### Adding custom add-ons
 
-1. Place `.tar` or `.tgz` in `roles/splunk_docker/files/`.
-2. Add entry to `roles/splunk_docker/vars/custom_addons.yml`.
-3. Re-run `doppler run -- ansible-playbook playbooks/site.yml`.
+1. Package the custom add-on as a version-free `.tar` archive.
+2. Upload the archive to object storage (e.g. using `mc cp`) and tag it with `version=X.Y.Z`.
+3. Add the entry to `roles/splunk_docker/vars/addons.yml` without a `splunkbase_id`.
+4. Re-run `doppler run -- ansible-playbook playbooks/site.yml`.
 
 ## Artifact store (object-storage / RustFS)
 

--- a/playbooks/validate.yml
+++ b/playbooks/validate.yml
@@ -25,6 +25,17 @@
       ansible.builtin.include_vars:
         file: ../roles/splunk_docker/defaults/main.yml
         name: _splunk_docker_defaults
+
+    - name: Set fallback global defaults for nested templates
+      ansible.builtin.set_fact:
+        splunk_docker_data_dir: "{{ splunk_docker_data_dir | default(_splunk_docker_defaults.splunk_docker_data_dir) }}"
+        splunk_docker_index_default_max_size_mb: "{{ splunk_docker_index_default_max_size_mb | default(_splunk_docker_defaults.splunk_docker_index_default_max_size_mb) }}"
+        splunk_docker_index_default_frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs | default(_splunk_docker_defaults.splunk_docker_index_default_frozen_time_secs) }}"
+
+    - name: Set derived fallback global defaults
+      ansible.builtin.set_fact:
+        splunk_docker_etc_dir: "{{ splunk_docker_etc_dir | default(_splunk_docker_defaults.splunk_docker_etc_dir) }}"
+
     - name: Set HEC namespace from environment
       ansible.builtin.set_fact:
         splunk_docker_hec_namespace: "{{ lookup('env', 'HEC_NAMESPACE') | default('', true) }}"

--- a/playbooks/validate.yml
+++ b/playbooks/validate.yml
@@ -29,8 +29,10 @@
     - name: Set fallback global defaults for nested templates
       ansible.builtin.set_fact:
         splunk_docker_data_dir: "{{ splunk_docker_data_dir | default(_splunk_docker_defaults.splunk_docker_data_dir) }}"
-        splunk_docker_index_default_max_size_mb: "{{ splunk_docker_index_default_max_size_mb | default(_splunk_docker_defaults.splunk_docker_index_default_max_size_mb) }}"
-        splunk_docker_index_default_frozen_time_secs: "{{ splunk_docker_index_default_frozen_time_secs | default(_splunk_docker_defaults.splunk_docker_index_default_frozen_time_secs) }}"
+        splunk_docker_index_default_max_size_mb: >-
+          {{ splunk_docker_index_default_max_size_mb | default(_splunk_docker_defaults.splunk_docker_index_default_max_size_mb) }}
+        splunk_docker_index_default_frozen_time_secs: >-
+          {{ splunk_docker_index_default_frozen_time_secs | default(_splunk_docker_defaults.splunk_docker_index_default_frozen_time_secs) }}
 
     - name: Set derived fallback global defaults
       ansible.builtin.set_fact:

--- a/roles/splunk_docker/vars/addons.yml
+++ b/roles/splunk_docker/vars/addons.yml
@@ -54,6 +54,7 @@ splunk_docker_addons:
   - {filename: splunk-add-on-for-servicenow.spl, app_dir: Splunk_TA_snow, splunkbase_id: 1928}
   - {filename: hurricane-labs-app-for-shodan.tar, app_dir: Hurricane_Labs_App_for_Shodan, splunkbase_id: 1767}
   - {filename: hurricane-labs-add-on-for-windows-powershell-transcript.tar, app_dir: TA-powershell_transcript, splunkbase_id: 4984}
+  - {filename: ta-studio.tar, app_dir: ta_studio, splunkbase_id: 8932}
 
   # --- object-storage, no Splunkbase match (manual upload; sync skips) ---
   # Hurricane Labs' Automox add-on was removed from Splunkbase. The archive is


### PR DESCRIPTION
### Summary
Adds the TA Studio app (Splunkbase ID 8932) to the Splunk Docker deployment and resolves variable namespacing issues in the validation playbook.

### Changes
- **Add-on Registry**: Added `ta_studio` (ID 8932) to `roles/splunk_docker/vars/addons.yml`.
- **Documentation**: Updated obsolete workflow steps and file references in `AGENTS.md` (renamed separate registry files to `addons.yml`).
- **Validation Playbook**: Added default fact definitions to `playbooks/validate.yml` to resolve template parsing errors when defaults are namespaced.
- **CI Configuration**: Fixed a missing YAML document start marker (`---`) in `.github/workflows/ai-pr-care.yml` to pass ansible-lint.

### Test Plan
- Ran the `sync-splunkbase.yml` playbook to mirror TA Studio v1.5.0 onto local MinIO object storage.
- Ran the `site.yml` playbook to successfully deploy the app to Splunk and restart the container.
- Ran `validate.yml` to verify the container is healthy and all apps are correctly installed.