### PR TITLE
fix(splunk_docker): return HTTP 202 for notifications/initialized

### DIFF
--- a/roles/splunk_docker/tasks/mcp_server.yml
+++ b/roles/splunk_docker/tasks/mcp_server.yml
@@ -53,6 +53,22 @@
             mode: '0644'
           notify: Restart Splunk container
 
+        # Answer notifications/initialized with HTTP 202 (No-body ACK) instead of
+        # 200. A strict MCP proxy (agentgateway) JSON-parses every non-202/204 2xx
+        # response body; the app's 200 + empty body hits EOF and the proxy returns
+        # 500, so Hermes and Claude Code abort the session. 202 makes the proxy
+        # short-circuit before parsing. The app is re-extracted from Splunkbase on
+        # every version change (vars/addons.yml, no pin_version), so this bin/ patch
+        # is re-applied each converge to self-heal. Anchored on the handler's log
+        # line so no unrelated status_code assignment is touched, and idempotent
+        # (the pattern's trailing 200 no longer matches once flipped to 202).
+        - name: Patch MCP Server notifications/initialized to return 202 (proxy compat)
+          ansible.builtin.replace:
+            path: "{{ splunk_docker_etc_dir }}/apps/{{ splunk_docker_mcp_app_entry.app_dir }}/bin/mcp_message.py"
+            regexp: '(Processing notifications/initialized request.\)\s*\n\s*status_code = )200'
+            replace: '\g<1>202'
+          notify: Restart Splunk container
+
     - name: Skip MCP configuration (app not installed)
       ansible.builtin.debug:
         msg: "MCP Server app not found — skipping configuration. Install the app first via Splunkbase."


### PR DESCRIPTION
## What

The Splunk MCP Server app answers the MCP `notifications/initialized` request with **HTTP 200 + an empty body**. A strict MCP proxy (agentgateway) JSON-parses every non-202/204 2xx response body and hits `EOF while parsing a value`, returning 500 and aborting the client session. This blocks routing Splunk's MCP endpoint through the shared proxy for strict clients.

## Change

Add an idempotent `ansible.builtin.replace` in the existing stat-gated MCP post-install block that flips the `notifications/initialized` handler from `status_code = 200` to `202` (No-body ACK) so the proxy short-circuits before parsing.

- Anchored on the handler's log line, so no unrelated `status_code = 200` is touched (verified against live source: the `else`/unknown-method branch returns a JSON-RPC error *body*, so its 200 is correct and left alone).
- Self-healing: the app has no `pin_version` and is re-extracted from Splunkbase on version change, so the source patch re-applies on every converge.
- Idempotent: the pattern's trailing `200` no longer matches once flipped to `202`.

Resolves the empty-body 500 tracked in `ansible-proxmox-apps#843`.

## Verification

- `ansible-lint` (production profile) passes.
- Post-converge: handler returns 202; strict MCP clients complete `initialize` -> `notifications/initialized` through the proxy without a 500.