### PR TITLE
feat(splunk): publish MCP credentials to OpenBao

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,9 @@ for ancillary services — those belong in `ansible-proxmox-apps` as LXC.
   `HEC_NAMESPACE` is set. `SPLUNK_HEC_TOKEN` is the shared legacy
   fallback (always required).
 - **HEC transport**: HTTPS (Splunk Docker image default, SSL enabled).
-- **Secrets**: All via Doppler (`doppler run --`).
+- **Secrets**: Deployment inputs come from Doppler (`doppler run --`). The role
+  publishes the shared Splunk MCP connection to OpenBao
+  `secret/ai/mcp/splunk` when explicitly enabled.
 
 ## Dependencies
 
@@ -75,7 +77,7 @@ documented once at
 ### External services
 
 - **Doppler**: Secrets for `SPLUNK_PASSWORD`, `HEC_NAMESPACE`,
-  `SPLUNK_HEC_TOKEN`, `SPLUNK_MCP_TOKEN`, `PROXMOX_SSH_KEY_PATH`,
+  `SPLUNK_HEC_TOKEN`, `PROXMOX_SSH_KEY_PATH`,
   `OBJECT_STORAGE_ROOT_USER`, `OBJECT_STORAGE_ROOT_PASSWORD`.
 
 ## Sources of truth
@@ -138,7 +140,9 @@ multiple endpoints, keep these speed options in mind:
 - **Apps not visible**: Verify ownership is UID 41812.
 - **HEC not working**: Confirm `SPLUNK_HEC_TOKEN` in Doppler; set
   `HEC_NAMESPACE` for per-index tokens.
-- **MCP Server not responding**: Verify token minting via the app's `/services/mcp_token` endpoint; confirm port 8089 is accessible and `SPLUNK_MCP_URL` points to the `<mgmt-base>/services/mcp` path.
+- **MCP Server not responding**: Verify token minting via the app's
+  `/services/mcp_token` endpoint; confirm port 8089 is accessible and
+  `SPLUNK_MCP_URL` points to the `<mgmt-base>/services/mcp` path.
 
 ### Adding Splunkbase apps
 
@@ -183,14 +187,15 @@ Configure the MCP client in `dryvist/nix-ai` (`modules/mcp/`).
 
 ## Secrets management
 
-All secrets retrieved from Doppler at runtime. Required secrets:
+Deployment secrets are retrieved from Doppler at runtime. The Splunk MCP
+connection is an output published to OpenBao when explicitly enabled:
 
 | Secret | Purpose |
 | --- | --- |
 | `SPLUNK_PASSWORD` | Admin password |
 | `HEC_NAMESPACE` | UUID namespace for per-index HEC token derivation (optional) |
 | `SPLUNK_HEC_TOKEN` | Shared legacy HEC token (always required) |
-| `SPLUNK_MCP_TOKEN` | MCP Server Bearer token (client-side); minted per managed user (`splunk_docker_users`) via the app's `/services/mcp_token` endpoint and published to the secret store. The SPLUNK_MCP_URL must be the `<mgmt-base>/services/mcp` path. |
+| `SPLUNK_MCP_TOKEN` | Client-side MCP Bearer token minted per managed user and published with `SPLUNK_MCP_URL` to OpenBao `secret/ai/mcp/splunk` |
 | `PROXMOX_SSH_KEY_PATH` | SSH key for VM access |
 
 ## Tooling baseline (inherited from dryvist/.github)

--- a/README.md
+++ b/README.md
@@ -179,9 +179,13 @@ owner's roles, so searches run with the user's capabilities. Because Splunk
 returns a token's value **only once at creation**, minting is gated on a
 delivery path: set `splunk_docker_token_publish_openbao: true` and provide a
 write-capable OpenBao AppRole (`BAO_ADDR` / `BAO_TOKEN`) so the role merges the
-token into `secret/ai/hermes` (`SPLUNK_MCP_TOKEN`) without clobbering sibling
-keys. Until that is wired, users and roles are still reconciled; only the
-token mint is deferred.
+canonical `SPLUNK_MCP_URL` and `SPLUNK_MCP_TOKEN` fields into
+`secret/ai/mcp/splunk` without clobbering sibling keys. If Splunk already has a
+live token for the managed user and `mcp` audience, the role preserves it and
+does not mint a replacement. Until publication is wired, users and roles are
+still reconciled; only the token mint is deferred. The URL uses the
+inventory-derived Splunk FQDN when available and can be overridden with
+`splunk_docker_mcp_url`.
 
 ## Testing
 

--- a/roles/splunk_docker/README.md
+++ b/roles/splunk_docker/README.md
@@ -105,9 +105,16 @@ python3 -c "import uuid; print(uuid.uuid5(uuid.UUID('$HEC_NAMESPACE'), 'splunk-h
 ## MCP Server Verification
 
 The Splunk MCP Server (app 7931) enables AI agents to query Splunk directly
-via the Model Context Protocol (MCP). The MCP JSON-RPC endpoint clients connect to is `<mgmt-base>/services/mcp` (e.g. `SPLUNK_MCP_URL=https://<host>:8089/services/mcp`).
+via the Model Context Protocol (MCP). The MCP JSON-RPC endpoint clients connect
+to is `<mgmt-base>/services/mcp` (for example,
+`SPLUNK_MCP_URL=https://<host>:8089/services/mcp`).
 Tokens are minted via the app's `/services/mcp_token` endpoint. Configure the MCP client in
 `~/git/nix-ai/main/modules/mcp/default.nix`.
+
+When OpenBao publication is enabled, the role writes the shared connection as
+`SPLUNK_MCP_URL` and `SPLUNK_MCP_TOKEN` at `secret/ai/mcp/splunk`. The KV-v2
+write preserves sibling fields, and an existing live token for the managed user
+and `mcp` audience is not replaced.
 
 ### Available MCP Tools
 

--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -70,17 +70,22 @@ splunk_docker_token_audience: "mcp"
 # Empty string omits expires_on so Splunk applies its default token lifetime.
 splunk_docker_token_expires_on: "+90d"
 
-# When true, publish a freshly minted token to OpenBao so the consumer (Hermes)
-# reads it from the shared secrets engine. Requires a write-capable OpenBao
-# AppRole in the converge environment (see the *_openbao_* vars below). Inert
-# by default: the user is created and the token minted, but the JWT is only
-# surfaced for out-of-band placement until a write role is wired.
+# When true, publish the shared MCP connection to OpenBao. Requires a
+# write-capable OpenBao AppRole in the converge environment (see the
+# *_openbao_* vars below). Inert by default: the user is created, but a token is
+# minted only when it can be written to the canonical shared secret.
 splunk_docker_token_publish_openbao: false
 splunk_docker_token_openbao_addr: "{{ lookup('env', 'BAO_ADDR') | default('', true) }}"
 splunk_docker_token_openbao_token: "{{ lookup('env', 'BAO_TOKEN') | default('', true) }}"
 splunk_docker_token_openbao_mount: "secret"
-splunk_docker_token_openbao_path: "ai/hermes"
+splunk_docker_token_openbao_path: "ai/mcp/splunk"
+splunk_docker_url_openbao_key: "SPLUNK_MCP_URL"
 splunk_docker_token_openbao_key: "SPLUNK_MCP_TOKEN"
+splunk_docker_mcp_host: >-
+  {{ (hostname ~ '.' ~ tofu_data.domain)
+     if (hostname is defined and tofu_data is defined and tofu_data.domain is defined)
+     else ansible_host }}
+splunk_docker_mcp_url: "https://{{ splunk_docker_mcp_host }}:{{ splunk_docker_mgmt_port }}/services/mcp"
 
 # Splunk Web SSL (enableSplunkWebSSL)
 splunk_docker_web_ssl: true

--- a/roles/splunk_docker/tasks/manage_one_user.yml
+++ b/roles/splunk_docker/tasks/manage_one_user.yml
@@ -116,7 +116,7 @@
         body_format: json
         body:
           data: >-
-            {{ (splunk_docker_bao_current.json.data.data | default({}))
+            {{ (splunk_docker_bao_current.json | default({}, true)).get('data', {}).get('data', {})
                | combine({
                    splunk_docker_url_openbao_key: splunk_docker_mcp_url,
                    splunk_docker_token_openbao_key: splunk_docker_token_mint.json.token

--- a/roles/splunk_docker/tasks/manage_one_user.yml
+++ b/roles/splunk_docker/tasks/manage_one_user.yml
@@ -105,9 +105,9 @@
         - splunk_docker_token_mint is not skipped
       no_log: true
 
-    # KV v2 write replaces the whole secret, so merge the new key over the
-    # current data to avoid clobbering sibling keys (e.g. HERMES_GITHUB_APP_*).
-    - name: "Publish {{ splunk_user.name }} token to OpenBao ({{ splunk_docker_token_openbao_key }})"
+    # KV v2 write replaces the whole secret, so merge the canonical connection
+    # fields over the current data to avoid clobbering sibling keys.
+    - name: "Publish {{ splunk_user.name }} MCP connection to OpenBao"
       ansible.builtin.uri:
         url: "{{ splunk_docker_token_openbao_addr }}/v1/{{ splunk_docker_token_openbao_mount }}/data/{{ splunk_docker_token_openbao_path }}"
         method: POST
@@ -117,7 +117,10 @@
         body:
           data: >-
             {{ (splunk_docker_bao_current.json.data.data | default({}))
-               | combine({splunk_docker_token_openbao_key: splunk_docker_token_mint.json.token}) }}
+               | combine({
+                   splunk_docker_url_openbao_key: splunk_docker_mcp_url,
+                   splunk_docker_token_openbao_key: splunk_docker_token_mint.json.token
+                 }) }}
         validate_certs: false
         status_code: [200, 204]
       when:
@@ -131,5 +134,6 @@
       User '{{ splunk_user.name }}' ensured (roles {{ splunk_user.roles | join(',') }}).
       Token minting is deferred because splunk_docker_token_publish_openbao is off —
       wire a write-capable OpenBao AppRole (BAO_ADDR/BAO_TOKEN) to mint + publish
-      {{ splunk_docker_token_openbao_key }} to {{ splunk_docker_token_openbao_mount }}/{{ splunk_docker_token_openbao_path }}.
+      {{ splunk_docker_url_openbao_key }} and {{ splunk_docker_token_openbao_key }} to
+      {{ splunk_docker_token_openbao_mount }}/{{ splunk_docker_token_openbao_path }}.
   when: not (splunk_docker_token_publish_openbao | bool)

--- a/tests/openbao_publish/verify.yml
+++ b/tests/openbao_publish/verify.yml
@@ -1,0 +1,55 @@
+---
+- name: Verify the canonical Splunk MCP publication contract
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - ../../roles/splunk_docker/defaults/main.yml
+  vars:
+    ansible_host: splunk.example.test
+    existing_secret:
+      SIBLING_FIELD: preserve-me
+      SPLUNK_MCP_URL: https://old.example.test:8089/services/mcp
+      SPLUNK_MCP_TOKEN: old-token
+    minted_token: new-token
+    token_list:
+      json:
+        entry:
+          - content:
+              claims:
+                sub: hermes
+                aud: mcp
+
+  tasks:
+    - name: Simulate the KV-v2 merge used by the publisher
+      ansible.builtin.set_fact:
+        merged_secret: >-
+          {{ existing_secret
+             | combine({
+                 splunk_docker_url_openbao_key: splunk_docker_mcp_url,
+                 splunk_docker_token_openbao_key: minted_token
+               }) }}
+        live_token_exists: >-
+          {{ (token_list.json.entry | default([]))
+             | map(attribute='content.claims') | select('defined')
+             | selectattr('sub', 'defined') | selectattr('sub', 'equalto', 'hermes')
+             | selectattr('aud', 'defined') | selectattr('aud', 'equalto', splunk_docker_token_audience)
+             | list | length > 0 }}
+
+    - name: Simulate minting only when no live token exists
+      ansible.builtin.set_fact:
+        replacement_token_minted: true
+      when: not live_token_exists
+
+    - name: Assert canonical path and field contract
+      ansible.builtin.assert:
+        that:
+          - splunk_docker_token_openbao_mount == 'secret'
+          - splunk_docker_token_openbao_path == 'ai/mcp/splunk'
+          - splunk_docker_url_openbao_key == 'SPLUNK_MCP_URL'
+          - splunk_docker_token_openbao_key == 'SPLUNK_MCP_TOKEN'
+          - merged_secret.SPLUNK_MCP_URL == 'https://splunk.example.test:8089/services/mcp'
+          - merged_secret.SPLUNK_MCP_TOKEN == minted_token
+          - merged_secret.SIBLING_FIELD == 'preserve-me'
+          - live_token_exists
+          - replacement_token_minted is undefined
+        fail_msg: Splunk MCP OpenBao publication contract is invalid


### PR DESCRIPTION
Publishes the shared Splunk MCP URL and token to the canonical OpenBao path while preserving sibling fields and existing-token mint behavior.\n\nValidation: offline Ansible contract test, ansible-lint, and repository hooks pass.\n\nLive publication is intentionally deferred.\n\nRefs: dryvist/ansible-proxmox-apps#932\nRefs: dryvist/ansible-splunk#341\nRefs: dryvist/nix-ai#1230\nRefs: dryvist/docs#165\nRefs: dryvist/docs-starlight#176