### PR TITLE
feat(splunk): enable Splunk MCP token publish to OpenBao

### DIFF
--- a/inventory/group_vars/splunk.yml
+++ b/inventory/group_vars/splunk.yml
@@ -25,3 +25,8 @@ splunk_docker_users:
   - name: hermes
     roles:
       - admin
+
+# Publish the shared Splunk MCP connection (SPLUNK_MCP_URL + minted
+# SPLUNK_MCP_TOKEN) to OpenBao secret/ai/mcp/splunk. Requires a write-capable
+# OpenBao AppRole token (BAO_ADDR/BAO_TOKEN) in the converge environment.
+splunk_docker_token_publish_openbao: true


### PR DESCRIPTION
Turns on `splunk_docker_token_publish_openbao` in `inventory/group_vars/splunk.yml` so the converge mints the hermes MCP token and publishes `SPLUNK_MCP_URL` + `SPLUNK_MCP_TOKEN` to OpenBao `secret/ai/mcp/splunk`.

#341 shipped the publish capability inert-by-default; this commits the production enablement so the state is reproducible (not a one-off `-e`). Requires a write-capable OpenBao AppRole token (BAO_ADDR/BAO_TOKEN) in the converge environment.

Idempotent: mint/publish are gated on the hermes user having no live `aud=mcp` token, so the first converge publishes once and reruns are no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)