### PR TITLE
docs: rename terraform-proxmox references to tofu-proxmox

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ for ancillary services — those belong in `ansible-proxmox-apps` as LXC.
 - **Firewall disabled**: Guest firewall is off
   (`splunk_docker_firewall_enabled: false`). Docker DNAT conflicts with
   iptables FORWARD chain. The Proxmox firewall is the sole network
-  security (see `dryvist/terraform-proxmox` firewall modules).
+  security (see `dryvist/tofu-proxmox` firewall modules).
 - **HEC tokens**: Per-index tokens are derived via
   `uuidv5(HEC_NAMESPACE, "splunk-hec-<index_name>")` when
   `HEC_NAMESPACE` is set. `SPLUNK_HEC_TOKEN` is the shared legacy
@@ -221,7 +221,7 @@ rules to work around stale tooling.
 
 | Repo | Relationship |
 | --- | --- |
-| `dryvist/terraform-proxmox` | Upstream: provisions Splunk VM + object-storage (RustFS) LXC |
+| `dryvist/tofu-proxmox` | Upstream: provisions Splunk VM + object-storage (RustFS) LXC |
 | `dryvist/ansible-proxmox-apps` | Peer: owns Cribl (sends to HEC), deploys the object storage (RustFS) |
 | `dryvist/ansible-proxmox` | Peer: Proxmox host config |
 | `dryvist/nix-ai` | MCP client configuration (`modules/mcp/`) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ For testing against a real Proxmox VM:
 
 1. Inventory resolves automatically (`inventory/load_tofu.yml`):
    `TOFU_INVENTORY_PATH` → the S3 artifact published by every
-   terraform-proxmox apply (needs only AWS read creds) → the local
+   tofu-proxmox apply (needs only AWS read creds) → the local
    gitignored cache the apply's after-hook writes. No manual sync step.
 
 2. Run playbooks with Doppler:

--- a/roles/splunk_docker/README.md
+++ b/roles/splunk_docker/README.md
@@ -22,7 +22,7 @@ ansible-galaxy collection install -r requirements.yml
 
 - Debian-based target host
 - Doppler secrets for SPLUNK_PASSWORD and SPLUNK_HEC_TOKEN
-- VM provisioned by terraform-proxmox with appropriate disk space
+- VM provisioned by tofu-proxmox with appropriate disk space
 
 ## Role Variables
 
@@ -67,7 +67,7 @@ splunk_docker_addons:
 ## Dependencies
 
 - community.docker collection
-- terraform-proxmox for VM provisioning
+- tofu-proxmox for VM provisioning
 - Doppler for secrets management
 
 ## HEC Token Setup


### PR DESCRIPTION
docs-only prose rename; code files left untouched to avoid renaming operational values (bucket/key/URL) — GitHub redirect keeps them working.