### PR TITLE
fix(splunk_docker): publish the Traefik-fronted MCP URL, not the raw mgmt endpoint

### DIFF
--- a/roles/splunk_docker/defaults/main.yml
+++ b/roles/splunk_docker/defaults/main.yml
@@ -97,7 +97,19 @@ splunk_docker_mcp_host: >-
   {{ (hostname ~ '.' ~ tofu_data.domain)
      if (hostname is defined and tofu_data is defined and tofu_data.domain is defined)
      else ansible_host }}
-splunk_docker_mcp_url: "https://{{ splunk_docker_mcp_host }}:{{ splunk_docker_mgmt_port }}/services/mcp"
+# Published URL = the Traefik-fronted `splunk-mgmt` ingress (a first-class
+# tofu ingress entry), NOT the raw https://<host>:<mgmt_port> endpoint. The
+# raw mgmt port serves Splunk's self-signed cert, which MCP clients rightly
+# refuse — the Hermes gateway parked its splunk MCP server on exactly this
+# ("failed initial connection ... parking") while the token itself was valid,
+# leaving the SIEM blind for cron monitoring (2026-07-18, Zammad incident).
+# Traefik terminates real TLS on the ingress name; publishing that URL makes
+# every consumer verify-clean by default. Fall back to the raw mgmt URL only
+# when tofu_data (and thus the ingress name derivation) is unavailable.
+splunk_docker_mcp_url: >-
+  {{ ('https://splunk-mgmt.' ~ tofu_data.domain ~ '/services/mcp')
+     if (tofu_data is defined and tofu_data.domain is defined)
+     else 'https://' ~ splunk_docker_mcp_host ~ ':' ~ splunk_docker_mgmt_port ~ '/services/mcp' }}
 
 # Splunk Web SSL (enableSplunkWebSSL)
 splunk_docker_web_ssl: true


### PR DESCRIPTION
The role published `https://<host>:<mgmt_port>/services/mcp` (raw management port, self-signed cert) to `secret/ai/mcp/splunk`. MCP clients rightly refuse that cert — the Hermes gateway parked its splunk MCP server on exactly this failure while the token was valid and in sync, leaving the SIEM blind for cron monitoring (2026-07-18 incident; Zammad ticket filed by the ai user).

Fix: publish the Traefik-fronted `splunk-mgmt` ingress URL (first-class tofu ingress entry, real TLS at Traefik) — verified live: the stored token gets 200 `initialize` + `tools/list` against it. Falls back to the raw mgmt URL only when `tofu_data` is unavailable.

Companion immediate data-fix: `secret/ai/mcp/splunk` SPLUNK_MCP_URL updated in place (this PR makes the next converge publish the same value instead of regressing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)