### PR TITLE
chore: forward Codex workflow credentials

### DIFF
--- a/.github/workflows/ai-pr-care.yml
+++ b/.github/workflows/ai-pr-care.yml
@@ -6,7 +6,7 @@
 #   refreshed per head SHA.
 #
 # Gates in the reusable workflows keep non-matching PRs at github-script cost.
-# Permissions are job-scoped and the secret is passed explicitly (zizmor:
+# Permissions are job-scoped and credentials are passed explicitly (zizmor:
 # excessive-permissions, secrets-inherit). No concurrency block on purpose: a
 # caller sharing the reusable workflow's exact concurrency group causes an
 # opaque 0-job startup_failure.
@@ -27,6 +27,7 @@ jobs:
     uses: dryvist/ai-workflows/.github/workflows/cc-dep-review.yml@main
     secrets:
       GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
   release-notes:
     permissions:
@@ -36,3 +37,4 @@ jobs:
     uses: dryvist/ai-workflows/.github/workflows/cc-release-notes.yml@main
     secrets:
       GH_ACTION_AI_API_KEY: ${{ secrets.GH_ACTION_AI_API_KEY }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Summary

Make inherited AI workflows switchable between Claude and Codex without caller rewrites.

## Changes

- Forward `OPENAI_API_KEY` beside the existing Claude credential.
- Preserve `GH_ACTION_AI_AGENT` as the only provider selector.

## Test Plan

- Validate the modified workflow with `actionlint`.
- Confirm the repository CI gate and CodeQL checks pass.

Refs: dryvist/ai-workflows#352