### PR TITLE
feat(splunk_docker): Hermes delivery SLO alert (INC-17088)

### DIFF
--- a/roles/splunk_docker/templates/savedsearches.conf.j2
+++ b/roles/splunk_docker/templates/savedsearches.conf.j2
@@ -137,6 +137,47 @@ quantity = 0
 {{ alert_deliver('LiteLLM router fallback/error spike', 'The LiteLLM router logged 20+ serving errors (MidStreamFallbackError / finish_reason error / cooldown) in 15 minutes. A backend engine is failing — if the MLX batch scheduler is wedged (broadcast_shapes in the Studio log), launchctl kickstart dev.vllm-mlx.server on the serving host is the sanctioned break-fix.', priority='urgent') }}
 
 {# ---------------------------------------------------------------------------
+   Hermes delivery SLO (INC-17088).
+
+   User SLO: Hermes must deliver >=1 USEFUL Slack work-product per hour. Prior
+   health checks validated scheduler/probe LIVENESS, not delivered output, so a
+   ~18h effective outage (2026-07-19) read green while every hourly message was
+   a cron-failure notice.
+
+   Signal reality (verified in Splunk): SUCCESSFUL Hermes cron deliveries are
+   SILENT in host=hermes-agent syslog — only failures log
+   (`cron.scheduler: Job '<name>' failed: ...`) plus Slack `delivery error`
+   lines. So a positive "confirmed-delivery age" is not measurable from syslog
+   alone (that would need the Slack channel ingested into Splunk — a follow-up).
+   This detector therefore keys on the FAILURE signal and fires only when BOTH
+   hourly useful jobs (splunk-digest, homelab-ai-fabric-status) have failed
+   within the window (distinct-job count >= 2) — i.e. no useful message could
+   have been delivered that hour. A single failing job stays quiet because the
+   other hourly job's success (silent) still satisfies the SLO.
+
+   Covers the "jobs fire but fail" SLO-violation mode. The "fleet paused/silent"
+   mode is covered by the brain-watchdog sustained-flap escalation in
+   ansible-proxmox-ai (PR #60). Together they monitor the SLO.
+--------------------------------------------------------------------------- #}
+[hermes_delivery_slo_violation]
+description = Fires when BOTH hourly Hermes work-product jobs (splunk-digest, homelab-ai-fabric-status) have failed within 90 minutes — no useful Slack message could have been delivered that hour, violating the >=1-useful-message-per-hour SLO. Successful deliveries are silent in syslog, so this uses the double-failure signal (dc(job) >= 2); the paused/flapping mode is covered by the ansible-proxmox-ai brain-watchdog sustained-flap alert. INC-17088.
+search = index=os host=hermes-agent "cron.scheduler" failed | rex "Job '(?<hermes_job>splunk-digest|homelab-ai-fabric-status)' failed" | where isnotnull(hermes_job) | stats dc(hermes_job) as jobs_failed values(hermes_job) as jobs | where jobs_failed >= 2
+dispatch.earliest_time = -90m
+dispatch.latest_time = now
+cron_schedule = */15 * * * *
+enableSched = 1
+is_visible = 1
+disabled = 0
+alert.severity = 4
+alert.suppress = 1
+alert.suppress.period = 90m
+alert.track = 1
+counttype = number of events
+relation = greater than
+quantity = 0
+{{ alert_deliver('Hermes hourly delivery failing (SLO)', 'Both hourly Hermes work-product jobs (splunk-digest AND homelab-ai-fabric-status) failed within 90 minutes — no useful Slack message reached the operator this hour (the >=1-useful-msg/hour SLO is violated). Investigate the brain/router path (INC-17083 wedge class) and the Hermes gateway. Successful deliveries are silent in syslog, so this fires on the double-failure signal; the paused/flapping mode is covered by the brain-watchdog sustained-flap alert.', priority='urgent') }}
+
+{# ---------------------------------------------------------------------------
    Model-eval regression.
 
    promptfoo eval suites publish per-model/per-suite scores into index=ai as

--- a/roles/splunk_docker/templates/savedsearches.conf.j2
+++ b/roles/splunk_docker/templates/savedsearches.conf.j2
@@ -161,7 +161,7 @@ quantity = 0
 --------------------------------------------------------------------------- #}
 [hermes_delivery_slo_violation]
 description = Fires when BOTH hourly Hermes work-product jobs (splunk-digest, homelab-ai-fabric-status) have failed within 90 minutes — no useful Slack message could have been delivered that hour, violating the >=1-useful-message-per-hour SLO. Successful deliveries are silent in syslog, so this uses the double-failure signal (dc(job) >= 2); the paused/flapping mode is covered by the ansible-proxmox-ai brain-watchdog sustained-flap alert. INC-17088.
-search = index=os host=hermes-agent "cron.scheduler" failed | rex "Job '(?<hermes_job>splunk-digest|homelab-ai-fabric-status)' failed" | where isnotnull(hermes_job) | stats dc(hermes_job) as jobs_failed values(hermes_job) as jobs | where jobs_failed >= 2
+search = index=os host=hermes-agent "cron.scheduler" failed ("splunk-digest" OR "homelab-ai-fabric-status") | rex "Job '(?<hermes_job>splunk-digest|homelab-ai-fabric-status)' failed" | stats dc(hermes_job) as jobs_failed values(hermes_job) as jobs | where jobs_failed >= 2
 dispatch.earliest_time = -90m
 dispatch.latest_time = now
 cron_schedule = */15 * * * *


### PR DESCRIPTION
# splunk_docker: Hermes delivery SLO alert (INC-17088)

## Why

User SLO: **Hermes must deliver ≥1 useful Slack work-product per hour.** The
2026-07-19 ~18h effective outage passed every liveness check (scheduler ticker,
watchdog running, `/v1/models`) because those measure **liveness, not delivered
output** — the exact monitoring gap this alert closes.

## Signal reality (verified in Splunk)

Successful Hermes cron deliveries are **SILENT** in `host=hermes-agent` syslog —
only failures log (`cron.scheduler: Job '<name>' failed`) plus Slack
`delivery error` lines. So a positive "confirmed-delivery age" is not measurable
from syslog alone (that needs the Slack channel ingested into Splunk — a
follow-up). This detector therefore keys on the **failure** signal.

## What it does

Fires only when **BOTH** hourly useful jobs (`splunk-digest`,
`homelab-ai-fabric-status`) have failed within 90 min (`dc(job) >= 2`) — i.e. no
useful message could have reached the operator that hour. A single failing job
stays quiet because the other's silent success still satisfies the SLO. Rides
the existing `alert_deliver()` ntfy + Slack loud path; suppress 90m.

This covers the "jobs fire but fail" SLO-violation mode. The "fleet
paused/silent" mode is covered by the ansible-proxmox-ai brain-watchdog
sustained-flap escalation (PR #60). **Together they monitor the SLO.**

## Verification

- SPL fires (`jobs_failed=2`, jobs = both) over the 2026-07-19 outage window.
- SPL is correctly silent over a healthy 2026-07-18 window (no double-failure).

## Follow-up (noted, not built)

A fully positive "confirmed-useful-delivery age" would ingest #channel-hermes
into Splunk (a Slack modular input) and alert on post age directly. Deferred.

**DO NOT MERGE** — review + a user-gated Splunk converge deploy it.
