### PR TITLE
fix(splunk_docker): repair pre-role index-combine reference, add HEC stanza completeness check

### DIFF
--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -60,64 +60,86 @@
 
 
   tasks:
-    # Precedence trap: play-level vars_files (#14) clobbers inventory group_vars (#6).
-    # Load defaults into a namespace here so pre-role tasks can fall back safely,
-    # preserving any group_vars overrides before the role executes.
-    - name: Load splunk_docker role defaults (namespaced, pre-role fallback)
-      ansible.builtin.include_vars:
-        dir: ../roles/splunk_docker/defaults/main
-        name: _splunk_docker_defaults
+    # Wrapped in block/always so the HEC completeness check at the bottom
+    # fires no matter where in this sequence a task fails — a converge that
+    # fails partway (or that silently "succeeds" after rendering an
+    # incomplete inputs.conf) is exactly the condition that let 20 of 36
+    # indexes run with no HEC listener for 9 days, undetected.
+    - name: Deploy Splunk, then verify every configured index actually has a live HEC listener
+      block:
+        # Precedence trap: play-level vars_files (#14) clobbers inventory group_vars (#6).
+        # Load defaults into a namespace here so pre-role tasks can fall back safely,
+        # preserving any group_vars overrides before the role executes.
+        #
+        # `_splunk_docker_defaults.splunk_docker_indexes` (the combine of
+        # splunk_docker_indexes_core + splunk_docker_indexes_extra, defined in
+        # 10-custom-indexes-extra.yml) is unusable here: normal role-defaults
+        # merging flattens all default files into one namespace before that
+        # combine template is ever evaluated, but include_vars: dir: with name:
+        # loads it lazily, so at access time `splunk_docker_indexes_core` (a bare
+        # name living in a SIBLING file) isn't in scope and the combine dies with
+        # "'splunk_docker_indexes_core' is undefined". Every call site below
+        # reconstructs the same combine directly from the two namespaced halves
+        # instead of trusting the pre-combined field.
+        - name: Load splunk_docker role defaults (namespaced, pre-role fallback)
+          ansible.builtin.include_vars:
+            dir: ../roles/splunk_docker/defaults/main
+            name: _splunk_docker_defaults
 
-    - name: Validate required environment variables
-      ansible.builtin.assert:
-        that:
-          - lookup('env', 'SPLUNK_PASSWORD') | length > 0
-          - lookup('env', 'SPLUNK_HEC_TOKEN') | length > 0
-          - lookup('env', 'HEC_NAMESPACE') | length > 0
-        fail_msg: >-
-          SPLUNK_PASSWORD, SPLUNK_HEC_TOKEN, and HEC_NAMESPACE must be set
-          (use: doppler run -- ansible-playbook ...). HEC_NAMESPACE is no
-          longer optional: every per-index HEC token is derived from it, so
-          a run without it silently re-templates inputs.conf down to only
-          the legacy token and drops every per-index sender's token —
-          causing a live multi-index ingest outage on the next restart.
-      run_once: true
-      delegate_to: localhost
+        - name: Validate required environment variables
+          ansible.builtin.assert:
+            that:
+              - lookup('env', 'SPLUNK_PASSWORD') | length > 0
+              - lookup('env', 'SPLUNK_HEC_TOKEN') | length > 0
+              - lookup('env', 'HEC_NAMESPACE') | length > 0
+            fail_msg: >-
+              SPLUNK_PASSWORD, SPLUNK_HEC_TOKEN, and HEC_NAMESPACE must be set
+              (use: doppler run -- ansible-playbook ...). HEC_NAMESPACE is no
+              longer optional: every per-index HEC token is derived from it, so
+              a run without it silently re-templates inputs.conf down to only
+              the legacy token and drops every per-index sender's token —
+              causing a live multi-index ingest outage on the next restart.
+          run_once: true
+          delegate_to: localhost
 
-    - name: Set Splunk credentials from environment
-      ansible.builtin.set_fact:
-        splunk_docker_password: "{{ lookup('env', 'SPLUNK_PASSWORD') }}"
-        splunk_docker_hec_namespace: "{{ lookup('env', 'HEC_NAMESPACE') }}"
-      no_log: true
+        - name: Set Splunk credentials from environment
+          ansible.builtin.set_fact:
+            splunk_docker_password: "{{ lookup('env', 'SPLUNK_PASSWORD') }}"
+            splunk_docker_hec_namespace: "{{ lookup('env', 'HEC_NAMESPACE') }}"
+          no_log: true
 
-    - name: Validate HEC_NAMESPACE is a valid UUID
-      ansible.builtin.assert:
-        that:
-          - splunk_docker_hec_namespace is match('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
-        fail_msg: >-
-          HEC_NAMESPACE must be a valid UUID (e.g. uuidgen output).
-          Got: {{ splunk_docker_hec_namespace | default('(empty)') }}
+        - name: Validate HEC_NAMESPACE is a valid UUID
+          ansible.builtin.assert:
+            that:
+              - splunk_docker_hec_namespace is match('^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
+            fail_msg: >-
+              HEC_NAMESPACE must be a valid UUID (e.g. uuidgen output).
+              Got: {{ splunk_docker_hec_namespace | default('(empty)') }}
 
-    # Derive a dedicated per-index HEC token via UUID v5 (Ansible core to_uuid:
-    # uuid5('splunk-hec-<index>', HEC_NAMESPACE)). The legacy token deliberately
-    # stays = SPLUNK_HEC_TOKEN (NOT derived) so rotating it does not disturb
-    # per-index tokens — senders migrate to their per-index token one at a
-    # time, then legacy is retired.
-    - name: Derive per-index HEC token values from namespace
-      vars:
-        index_names: "{{ (splunk_docker_indexes | default(_splunk_docker_defaults.splunk_docker_indexes)) | map(attribute='name') | list }}"
-      ansible.builtin.set_fact:
-        splunk_docker_hec_token_values: >-
-          {{
-            dict(index_names | zip(
-              index_names | map('regex_replace', '^', 'splunk-hec-') | map('to_uuid', splunk_docker_hec_namespace)
-            )) | combine({'legacy': lookup('env', 'SPLUNK_HEC_TOKEN')})
-          }}
-      no_log: true
+        # Derive a dedicated per-index HEC token via UUID v5 (Ansible core to_uuid:
+        # uuid5('splunk-hec-<index>', HEC_NAMESPACE)). The legacy token deliberately
+        # stays = SPLUNK_HEC_TOKEN (NOT derived) so rotating it does not disturb
+        # per-index tokens — senders migrate to their per-index token one at a
+        # time, then legacy is retired.
+        - name: Derive per-index HEC token values from namespace
+          vars:
+            index_names: "{{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core + _splunk_docker_defaults.splunk_docker_indexes_extra))) | map(attribute='name') | list }}"
+          ansible.builtin.set_fact:
+            splunk_docker_hec_token_values: >-
+              {{
+                dict(index_names | zip(
+                  index_names | map('regex_replace', '^', 'splunk-hec-') | map('to_uuid', splunk_docker_hec_namespace)
+                )) | combine({'legacy': lookup('env', 'SPLUNK_HEC_TOKEN')})
+              }}
+          no_log: true
 
-    - name: Deploy Splunk Docker
-      ansible.builtin.include_role:
-        name: splunk_docker
+        - name: Deploy Splunk Docker
+          ansible.builtin.include_role:
+            name: splunk_docker
+      always:
+        - name: Verify every configured index has a live, enabled HEC input stanza
+          ansible.builtin.include_tasks: ../roles/splunk_docker/tasks/verify_hec_completeness.yml
+          when: _splunk_docker_defaults is defined
 
   post_tasks:
     - name: Wait for Splunk to be ready after any restarts

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -123,7 +123,9 @@
         # time, then legacy is retired.
         - name: Derive per-index HEC token values from namespace
           vars:
-            index_names: "{{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core + _splunk_docker_defaults.splunk_docker_indexes_extra))) | map(attribute='name') | list }}"
+            index_names: >-
+              {{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core +
+                 _splunk_docker_defaults.splunk_docker_indexes_extra))) | map(attribute='name') | list }}
           ansible.builtin.set_fact:
             splunk_docker_hec_token_values: >-
               {{

--- a/playbooks/tasks/validate/00-setup.yml
+++ b/playbooks/tasks/validate/00-setup.yml
@@ -23,7 +23,9 @@
 
 - name: Derive per-index HEC token values from namespace
   vars:
-    index_names: "{{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core + _splunk_docker_defaults.splunk_docker_indexes_extra))) | map(attribute='name') | list }}"
+    index_names: >-
+      {{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core +
+         _splunk_docker_defaults.splunk_docker_indexes_extra))) | map(attribute='name') | list }}
   ansible.builtin.set_fact:
     splunk_docker_hec_token_values: >-
       {{

--- a/playbooks/tasks/validate/00-setup.yml
+++ b/playbooks/tasks/validate/00-setup.yml
@@ -23,7 +23,7 @@
 
 - name: Derive per-index HEC token values from namespace
   vars:
-    index_names: "{{ (splunk_docker_indexes | default(_splunk_docker_defaults.splunk_docker_indexes)) | map(attribute='name') | list }}"
+    index_names: "{{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core + _splunk_docker_defaults.splunk_docker_indexes_extra))) | map(attribute='name') | list }}"
   ansible.builtin.set_fact:
     splunk_docker_hec_token_values: >-
       {{

--- a/playbooks/tasks/validate/02-ports-and-hec.yml
+++ b/playbooks/tasks/validate/02-ports-and-hec.yml
@@ -62,7 +62,7 @@
     status_code: 200
   register: splunk_docker_hec_test
   failed_when: false
-  loop: "{{ (splunk_docker_indexes | default(_splunk_docker_defaults.splunk_docker_indexes)) }}"
+  loop: "{{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core + _splunk_docker_defaults.splunk_docker_indexes_extra))) }}"
   loop_control:
     label: "{{ item.name }}"
   no_log: true

--- a/roles/splunk_docker/tasks/verify_hec_completeness.yml
+++ b/roles/splunk_docker/tasks/verify_hec_completeness.yml
@@ -1,0 +1,41 @@
+---
+# Fires from site.yml's `always:` regardless of whether the deploy tasks
+# above succeeded — a converge that fails partway is exactly the condition
+# that let 20 of 36 indexes go without a live HEC listener for 9 days,
+# undetected (root cause: a whole-file inputs.conf template overwrite driven
+# by a narrowed index list, which exits 0). Checked against Splunk's own REST
+# API rather than local derived state, so it still means something even if
+# credential/token derivation earlier in the play never ran.
+- name: Query live HEC input stanzas from Splunk
+  ansible.builtin.uri:
+    url: "https://localhost:{{ (splunk_docker_mgmt_port | default(_splunk_docker_defaults.splunk_docker_mgmt_port)) }}/services/data/inputs/http?output_mode=json&count=0"
+    validate_certs: false
+    method: GET
+    user: admin
+    password: "{{ splunk_docker_password | default(lookup('env', 'SPLUNK_PASSWORD')) }}"
+    force_basic_auth: true
+    status_code: 200
+  register: verify_hec_live_stanzas
+  failed_when: false
+  no_log: true
+
+- name: Compute which configured indexes are missing a live, enabled HEC stanza
+  vars:
+    verify_hec_expected: "{{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core + _splunk_docker_defaults.splunk_docker_indexes_extra))) | map(attribute='name') | list }}"
+    verify_hec_live: >-
+      {{ ((verify_hec_live_stanzas.json | default({})).entry | default([]))
+         | selectattr('content.disabled', 'equalto', false)
+         | map(attribute='name') | map('regex_replace', '^http://', '') | list }}
+  ansible.builtin.set_fact:
+    verify_hec_missing: "{{ verify_hec_expected | difference(verify_hec_live) }}"
+
+- name: Fail if any configured index lacks a live, enabled HEC stanza
+  ansible.builtin.fail:
+    msg: >-
+      {{ verify_hec_missing | length }} of
+      {{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core + _splunk_docker_defaults.splunk_docker_indexes_extra))) | length }}
+      configured indexes have no live, enabled HEC input stanza:
+      {{ verify_hec_missing | join(', ') }}.
+      A converge reporting success while an index has no HEC listener is
+      exactly the outage this check exists to catch.
+  when: verify_hec_missing | length > 0

--- a/roles/splunk_docker/tasks/verify_hec_completeness.yml
+++ b/roles/splunk_docker/tasks/verify_hec_completeness.yml
@@ -21,13 +21,24 @@
   failed_when: false
   no_log: true
 
+# Fail fast and specifically if the query itself didn't work, so a Splunk
+# outage or bad credential reads as that, not as "every index is missing."
+- name: Fail if the live HEC stanza query itself failed
+  ansible.builtin.fail:
+    msg: >-
+      Could not query Splunk's HEC input list (status
+      {{ splunk_docker_verify_hec_live_stanzas.status | default('unknown') }}) --
+      cannot verify index completeness. Check that Splunk is up and
+      SPLUNK_PASSWORD is correct.
+  when: (splunk_docker_verify_hec_live_stanzas.status | default(0)) != 200
+
 - name: Compute which configured indexes are missing a live, enabled HEC stanza
   vars:
     verify_hec_expected: >-
       {{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core +
          _splunk_docker_defaults.splunk_docker_indexes_extra))) | map(attribute='name') | list }}
     verify_hec_live: >-
-      {{ ((splunk_docker_verify_hec_live_stanzas.json | default({})).entry | default([]))
+      {{ (splunk_docker_verify_hec_live_stanzas.json.get('entry', []))
          | selectattr('content.disabled', 'equalto', false)
          | map(attribute='name') | map('regex_replace', '^http://', '') | list }}
   ansible.builtin.set_fact:

--- a/roles/splunk_docker/tasks/verify_hec_completeness.yml
+++ b/roles/splunk_docker/tasks/verify_hec_completeness.yml
@@ -7,35 +7,40 @@
 # API rather than local derived state, so it still means something even if
 # credential/token derivation earlier in the play never ran.
 - name: Query live HEC input stanzas from Splunk
+  vars:
+    splunk_docker_verify_mgmt_port: "{{ splunk_docker_mgmt_port | default(_splunk_docker_defaults.splunk_docker_mgmt_port) }}"
   ansible.builtin.uri:
-    url: "https://localhost:{{ (splunk_docker_mgmt_port | default(_splunk_docker_defaults.splunk_docker_mgmt_port)) }}/services/data/inputs/http?output_mode=json&count=0"
+    url: "https://localhost:{{ splunk_docker_verify_mgmt_port }}/services/data/inputs/http?output_mode=json&count=0"
     validate_certs: false
     method: GET
     user: admin
     password: "{{ splunk_docker_password | default(lookup('env', 'SPLUNK_PASSWORD')) }}"
     force_basic_auth: true
     status_code: 200
-  register: verify_hec_live_stanzas
+  register: splunk_docker_verify_hec_live_stanzas
   failed_when: false
   no_log: true
 
 - name: Compute which configured indexes are missing a live, enabled HEC stanza
   vars:
-    verify_hec_expected: "{{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core + _splunk_docker_defaults.splunk_docker_indexes_extra))) | map(attribute='name') | list }}"
+    verify_hec_expected: >-
+      {{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core +
+         _splunk_docker_defaults.splunk_docker_indexes_extra))) | map(attribute='name') | list }}
     verify_hec_live: >-
-      {{ ((verify_hec_live_stanzas.json | default({})).entry | default([]))
+      {{ ((splunk_docker_verify_hec_live_stanzas.json | default({})).entry | default([]))
          | selectattr('content.disabled', 'equalto', false)
          | map(attribute='name') | map('regex_replace', '^http://', '') | list }}
   ansible.builtin.set_fact:
-    verify_hec_missing: "{{ verify_hec_expected | difference(verify_hec_live) }}"
+    splunk_docker_verify_hec_missing: "{{ verify_hec_expected | difference(verify_hec_live) }}"
 
 - name: Fail if any configured index lacks a live, enabled HEC stanza
   ansible.builtin.fail:
     msg: >-
-      {{ verify_hec_missing | length }} of
-      {{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core + _splunk_docker_defaults.splunk_docker_indexes_extra))) | length }}
+      {{ splunk_docker_verify_hec_missing | length }} of
+      {{ (splunk_docker_indexes | default((_splunk_docker_defaults.splunk_docker_indexes_core +
+         _splunk_docker_defaults.splunk_docker_indexes_extra))) | length }}
       configured indexes have no live, enabled HEC input stanza:
-      {{ verify_hec_missing | join(', ') }}.
+      {{ splunk_docker_verify_hec_missing | join(', ') }}.
       A converge reporting success while an index has no HEC listener is
       exactly the outage this check exists to catch.
-  when: verify_hec_missing | length > 0
+  when: splunk_docker_verify_hec_missing | length > 0


### PR DESCRIPTION
## Summary
- Fixes a latent bug from the defaults-file split (#481): `site.yml` and `validate.yml`'s pre-role `include_vars: dir:` fallback referenced a combine field spanning two defaults files, which resolves fine as normal role defaults (flat merge at role-run time) but is undefined when loaded ad-hoc. Every call site now references the two source lists directly.
- Wraps the "Deploy Splunk" play's tasks in `block`/`always` and adds `roles/splunk_docker/tasks/verify_hec_completeness.yml`, which queries Splunk's REST API for live, enabled HEC input stanzas and fails the run if any configured index lacks one. Runs in `always:` so it fires even if the deploy fails partway.
- Note: this check verifies a listener exists, not that data is arriving on it — those are different failure modes (stanza-presence catches the whole-file-overwrite deletion mechanism; a follow-up data-arrival check, scoped against which indexes are expected to be actively producing, is tracked separately).

## Test plan
- [x] `ansible-playbook playbooks/site.yml --syntax-check`
- [x] Ran live against the Splunk host: converge succeeded, all 36 configured indexes confirmed with live enabled HEC stanzas via the new check
- [x] Confirmed the check runs inside `always:` (verified task ordering in a live run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)